### PR TITLE
Web console API + Support for more stuff

### DIFF
--- a/data/ek.js
+++ b/data/ek.js
@@ -1,7 +1,8 @@
 function main() {
-  let x = "e"
+  let x = "this is the value of x"
   let y = "this is truly a moment"
-  print(x)
+  console.log(x)
+  console.log(y)
 }
 
 main()

--- a/src/bali/grammar/statement.nim
+++ b/src/bali/grammar/statement.nim
@@ -42,6 +42,7 @@ type
 
   Function* = ref object of Scope
     name*: string
+    arguments*: seq[uint]
 
   Statement* = object
     case kind*: StatementKind

--- a/src/bali/grammar/tokenizer.nim
+++ b/src/bali/grammar/tokenizer.nim
@@ -150,10 +150,22 @@ proc consumeString*(tokenizer: Tokenizer): Token =
   info "tokenizer: consume string with closing character: " & closesWith
   tokenizer.advance()
 
-  var str: string
+  var 
+    str: string
+    ignoreNextQuote = false
 
-  while (not tokenizer.eof()) and not (&tokenizer.charAt() == closesWith):
-    str &= &tokenizer.charAt()
+  while not tokenizer.eof():
+    let c = &tokenizer.charAt()
+
+    if c == closesWith and not ignoreNextQuote:
+      break
+    
+    if c == '\\':
+      ignoreNextQuote = true
+      tokenizer.advance()
+      continue
+
+    str &= c
     tokenizer.advance()
 
   let malformed = str.endsWith(closesWith)

--- a/src/bali/runtime/interpreter.nim
+++ b/src/bali/runtime/interpreter.nim
@@ -8,6 +8,7 @@ import mirage/runtime/prelude
 import bali/grammar/prelude
 import bali/internal/sugar
 import bali/runtime/[normalize]
+import bali/stdlib/prelude
 import crunchy, pretty
 
 type
@@ -59,6 +60,7 @@ proc generateIR*(runtime: Runtime, stmt: Statement) =
     )
   of Call:
     if runtime.vm.hasBuiltin(stmt.fn):
+      info "interpreter: generate IR for calling builtin: " & stmt.fn
       let args =
         (proc(): seq[MAtom] =
           var x: seq[MAtom]
@@ -74,7 +76,20 @@ proc generateIR*(runtime: Runtime, stmt: Statement) =
     else:
       let nam = stmt.fn.normalizeIRName()
       info "interpreter: generate IR for calling function (normalized): " & nam
+      
+      for i, arg in stmt.arguments:
+        case arg.kind
+        of cakIdent:
+          runtime.ir.passArgument(runtime.index(arg.ident))
+        of cakAtom:
+          for child in stmt.expand():
+            runtime.generateIR(
+              child
+            )
+
       runtime.ir.call(nam)
+      #runtime.ir.resetArgs()
+      discard runtime.ir.addOp IROperation(opcode: CrashInterpreter)
   else:
     warn "interpreter: unimplemented IR generation directive: " & $stmt.kind
 
@@ -114,7 +129,8 @@ proc generateIRForScope*(runtime: Runtime, scope: Scope) =
       runtime.generateIR(stmt, addrIdx)]#
 
 proc run*(runtime: Runtime) =
-  #runtime.generateIRForStd()
+  console.generateStdIr(runtime.vm, runtime.ir)
+
   runtime.generateIRForScope(runtime.ast.scopes[0])
 
   let source = runtime.ir.emit()

--- a/src/bali/stdlib/console.nim
+++ b/src/bali/stdlib/console.nim
@@ -1,0 +1,52 @@
+## JavaScript console API standard interface
+import std/[tables, logging]
+import mirage/ir/generator
+import mirage/runtime/prelude
+import bali/runtime/normalize
+import bali/internal/sugar
+import pretty
+
+type
+  ConsoleLevel* {.pure.} = enum
+    Debug
+    Error
+    Info
+    Log
+    Trace
+    Warn
+
+  ConsoleDelegate* = proc(level: ConsoleLevel, msg: string)
+
+const
+  DefaultConsoleDelegate* = proc(level: ConsoleLevel, msg: string) =
+    echo $level & ": " & msg
+
+var delegate: ConsoleDelegate = DefaultConsoleDelegate
+
+proc attachConsoleDelegate*(del: ConsoleDelegate) {.inline.} =
+  delegate = del
+
+proc consoleLogIR*(vm: PulsarInterpreter, generator: IRGenerator) =
+  # generate binding interface
+  generator.newModule(normalizeIRName "console.log")
+  generator.call("BALI_CONSOLELOG")
+
+  vm.registerBuiltin("BALI_CONSOLELOG",
+    proc(op: Operation) =
+      echo "\n\n\nI WAS CALLED MEOW :33333"
+      for arg in vm.registers.callArgs:
+        let value =
+          case arg.kind
+          of Integer:
+            $(&arg.getInt())
+          of String:
+            $(&arg.getStr())
+          else: ""
+
+        delegate(ConsoleLevel.Log, value)
+  )
+
+proc generateStdIR*(vm: PulsarInterpreter, generator: IRGenerator) =
+  info "console: generating IR interfaces"
+  
+  consoleLogIR(vm, generator)

--- a/src/bali/stdlib/prelude.nim
+++ b/src/bali/stdlib/prelude.nim
@@ -1,0 +1,3 @@
+import ./[console]
+
+export console


### PR DESCRIPTION
Adding support for the Web console API as the WhatWG document suggests. Only `console.log` has been implemented.
All logging requests are sent to a console delegate (like how V8 does it) and the delegate decides how to log the messages.

This PR has led me to find a pretty major bug in Mirage as well, which I'll need to fix:
```
Func A -> Calls Func B
Func B -> Calls Func C
Func C -> Returns to Func B
Func B -> Halts interpreter, mistakenly thinking that all instructions have been executed.
```