### PR TITLE
Add support for parsing and evaluating function arguments as specified in their signature.

### DIFF
--- a/bali.nimble
+++ b/bali.nimble
@@ -10,8 +10,6 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 2.0.2"
-requires "regex >= 0.25.0"
-
 requires "mirage >= 0.1.5"
 requires "librng >= 0.1.3"
 requires "pretty >= 0.1.0"

--- a/bali.nimble
+++ b/bali.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.1.9"
 author        = "xTrayambak"
 description   = "The Bali JavaScript Engine"
 license       = "MIT"

--- a/data/do.js
+++ b/data/do.js
@@ -1,3 +1,5 @@
-function output_this(x) {
-  console.log(x)
+function output_this() {
+  console.log("Hello world!", "hey there!")
 }
+
+output_this()

--- a/data/tin.js
+++ b/data/tin.js
@@ -1,0 +1,6 @@
+function do_smt(x) {
+  console.log(x)
+}
+
+do_smt("billions must inline")
+do_smt("do_smt is called with the `x` parameter and it can be anything you want, really!")

--- a/src/bali/grammar/ast.nim
+++ b/src/bali/grammar/ast.nim
@@ -1,5 +1,6 @@
 import std/[options]
 import bali/internal/sugar
+import pretty
 import ./[statement, scopes]
 
 type
@@ -35,10 +36,12 @@ iterator items*(ast: AST): Scope =
   for scope in ast.scopes:
     yield scope
 
-func function*(name: string, stmts: seq[Statement]): Function {.inline.} =
+func function*(name: string, stmts: seq[Statement], args: seq[string]): Function {.inline.} =
+  print args
   Function(
     name: name,
-    stmts: stmts
+    stmts: stmts,
+    arguments: args
   )
 
 proc newAST*: AST {.inline.} =

--- a/src/bali/grammar/parser.nim
+++ b/src/bali/grammar/parser.nim
@@ -115,6 +115,7 @@ proc parseFunction*(parser: Parser): Option[Function] =
   var 
     metLParen = false
     metRParen = false
+    arguments: seq[string] 
 
   # TODO: parameter parsing
   while not parser.tokenizer.eof:
@@ -141,11 +142,19 @@ proc parseFunction*(parser: Parser): Option[Function] =
         parser.error Other, "missing ) before start of function scope"
 
       break
+    of TokenKind.Whitespace: discard
+    of TokenKind.Identifier:
+      info "parser: appending identifier to expected function argument signature: " & tok.ident
+      if metRParen:
+        parser.error Other, "unexpected identifier after end of function signature"
+
+      arguments &=
+        tok.ident
     else: 
       warn "parser (unimplemented): whilst parsing parameters: "
       print tok
       discard # parameter parser goes here :3
-  
+
   var body: seq[Statement]
   info "parser: parse function body: " & &name
   while not parser.tokenizer.eof:
@@ -170,7 +179,7 @@ proc parseFunction*(parser: Parser): Option[Function] =
     body &= &stmt
   
   info "parser: parsed function: " & &name
-  some function(&name, body)
+  some function(&name, body, arguments)
 
 proc parseAtom*(parser: Parser, token: Token): Option[MAtom] =
   info "parser: trying to parse an atom out of " & $token.kind

--- a/src/bali/grammar/statement.nim
+++ b/src/bali/grammar/statement.nim
@@ -42,7 +42,7 @@ type
 
   Function* = ref object of Scope
     name*: string
-    arguments*: seq[uint]
+    arguments*: seq[string] ## expected arguments!
 
   Statement* = object
     case kind*: StatementKind
@@ -61,6 +61,9 @@ type
     of NewFunction:
       fnName*: string
       body*: Scope
+
+proc hash*(fn: Function): Hash {.inline.} =
+  hash((fn.name, fn.arguments))
 
 proc hash*(stmt: Statement): Hash {.inline.} =
   var hash: Hash
@@ -147,7 +150,7 @@ proc expand*(stmt: Statement): seq[Statement] =
     for i, arg in stmt.arguments:
       if arg.kind == cakAtom:
         result &= createImmutVal(
-          "callarg_" & $hash(stmt) & '_' & $i,
+          '@' & $hash(stmt) & '_' & $i,
           arg.atom
         ) # XXX: should this be mutable?
   else: discard

--- a/src/bali/runtime/normalize.nim
+++ b/src/bali/runtime/normalize.nim
@@ -31,6 +31,10 @@ proc normalizeIRName*(name: string): string =
       buffer &= "eight"
     of '9':
       buffer &= "nine"
+    of '_':
+      buffer &= "underscore"
+    of '@':
+      buffer &= "at"
     else:
       raise newException(ValueError, "Found invalid character in buffer during normalization (pos " & $i & "): '" & c & "' in " & name)
 


### PR DESCRIPTION
An example is provided in `data/tin.js`. Here's one:
```js
function output(x) {
  console.log(x)
}

output("Hello, world!")
``` 
This is now executable by Bali.