### PR TITLE
Add support for web URL spec alongside constructor syntax support

### DIFF
--- a/bali.nimble
+++ b/bali.nimble
@@ -10,7 +10,7 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 2.0.2"
-requires "mirage >= 0.1.7"
+requires "mirage >= 0.1.8"
 requires "librng >= 0.1.3"
 requires "pretty >= 0.1.0"
 requires "colored_logger >= 0.1.0"
@@ -18,4 +18,11 @@ requires "colored_logger >= 0.1.0"
 task balde, "Compile the Bali debugger":
   exec "nimble uninstall bali"
   exec "nimble install"
-  exec "nim c -d:release -d:speed -d:flto --out:./balde src/bali/balde.nim"
+
+  when defined(release):
+    exec "nim c -d:release -d:speed -d:flto --out:./balde src/bali/balde.nim"
+  else:
+    when not defined(gdb):
+      exec "nim c --out:./balde src/bali/balde.nim"
+    else:
+      exec "nim c -d:useMalloc --debugger:native --profiler:on --outer:./balde src/bali/balde.nim"

--- a/data/no.js
+++ b/data/no.js
@@ -1,0 +1,5 @@
+let x = 42
+
+if (x == 42) {
+	console.log("yeet")
+}

--- a/data/uri_parse.js
+++ b/data/uri_parse.js
@@ -1,0 +1,2 @@
+const url = new URL("https://github.com/ferus-web/bali")
+console.log(url)

--- a/src/bali/balde.nim
+++ b/src/bali/balde.nim
@@ -8,7 +8,7 @@ when not isMainModule:
 import std/[times, tables, os, monotimes, logging]
 import bali/grammar/prelude
 import bali/runtime/prelude
-import climate, colored_logger, jsony
+import climate, colored_logger, jsony, pretty
 
 var 
   enableProfiler = false
@@ -60,12 +60,18 @@ proc execFile(ctx: Context, file: string) {.inline.} =
   
   profileThis "parse source code":
     let ast = parser.parse()
+
+  if ctx.cmdOptions.contains("dump-ast"):
+    print ast
   
   profileThis "allocate runtime":
     let runtime = newRuntime(file, ast)
 
   profileThis "execution time":
     runtime.run()
+
+  if ctx.cmdOptions.contains("dump-runtime-after-exec"):
+    print runtime
 
 proc baldeRun(ctx: Context): int =
   if not ctx.cmdOptions.contains("verbose") or ctx.cmdOptions.contains("v"):

--- a/src/bali/grammar/condition.nim
+++ b/src/bali/grammar/condition.nim
@@ -1,0 +1,27 @@
+import std/[options]
+import mirage/atom
+import bali/internal/sugar
+
+type
+  Gate* {.pure.} = enum
+    And
+    Or
+
+  Comparison* {.pure.} = enum
+    Equate
+    NotEquate
+
+  Condition* = ref object
+    next*: tuple[cond: Option[Condition], gate: Gate]
+
+    identA*, identB*: Option[string]
+    atomA*, atomB*: Option[MAtom]
+    comparison*: Comparison
+
+proc append*(cond: Condition, child: Condition, gate: Gate) =
+  var next = cond
+  while *next.next.cond:
+    next = &next.next.cond
+
+  next.next.cond = some(child)
+  next.next.gate = gate

--- a/src/bali/grammar/token.nim
+++ b/src/bali/grammar/token.nim
@@ -59,6 +59,8 @@ type
     RCurly
     LBracket
     RBracket
+    And
+    Or
     LParen
     RParen
     Period

--- a/src/bali/grammar/tokenizer.nim
+++ b/src/bali/grammar/tokenizer.nim
@@ -361,6 +361,35 @@ proc consumePlus*(tokenizer: Tokenizer): Token =
     return Token(kind: TokenKind.Add)
   else: discard
 
+proc consumeAmpersand*(tokenizer: Tokenizer): Token =
+  tokenizer.advance()
+  let next = tokenizer.charAt()
+  if !next:
+    return tokenizer.consumeInvalid()
+  
+  case &next
+  of '&':
+    info "tokenizer: consumed And operand"
+    tokenizer.advance()
+    return Token(kind: TokenKind.And)
+  else:
+    return tokenizer.consumeInvalid()
+
+proc consumePipe*(tokenizer: Tokenizer): Token =
+  tokenizer.advance()
+
+  let next = tokenizer.charAt()
+  if !next:
+    return tokenizer.consumeInvalid()
+  
+  case &next
+  of '|':
+    info "tokenizer: consumed Or operand"
+    tokenizer.advance()
+    return Token(kind: TokenKind.Or)
+  else:
+    return tokenizer.consumeInvalid()
+
 proc next*(tokenizer: Tokenizer): Token =
   let c = tokenizer.charAt()
 
@@ -425,6 +454,10 @@ proc next*(tokenizer: Tokenizer): Token =
     tokenizer.consumeExclaimation()
   of '+':
     tokenizer.consumePlus()
+  of '&':
+    tokenizer.consumeAmpersand()
+  of '|':
+    tokenizer.consumePipe()
   else:
     tokenizer.consumeInvalid()
 

--- a/src/bali/runtime/objects.nim
+++ b/src/bali/runtime/objects.nim
@@ -1,0 +1,34 @@
+## Utility for converting object types to MIR
+import std/[tables, logging]
+import mirage/atom
+import mirage/ir/generator
+import bali/internal/sugar
+
+type
+  BaliObject* = object
+    fields*: Table[string, MAtom]
+
+proc `[]=`*(obj: var BaliObject, key: string, atom: MAtom) {.inline.} =
+  obj.fields[key] = atom
+
+proc inject*(obj: BaliObject, pos: uint, ir: IRGenerator): uint =
+  var pos = pos
+
+  for field, atom in obj.fields:
+    inc pos
+    case atom.kind
+    of Integer:
+      discard ir.loadInt(pos, atom)
+    of String:
+      discard ir.loadStr(pos, atom)
+    else: unreachable
+
+  pos
+
+proc newBaliObject*(fields: openArray[string]): BaliObject {.inline.} =
+  var obj = BaliObject(fields: initTable[string, MAtom]())
+  
+  for field in fields:
+    obj[field] = null()
+
+  obj

--- a/src/bali/stdlib/fetch.nim
+++ b/src/bali/stdlib/fetch.nim
@@ -1,0 +1,3 @@
+## HTTP/fetch API
+## This uses ferus-sanchar by default, but you can change it by providing a compatible fetching delegate (like how Ferus will to shift the work to another process)
+import std/logging

--- a/src/bali/stdlib/prelude.nim
+++ b/src/bali/stdlib/prelude.nim
@@ -1,3 +1,3 @@
-import ./[console, math]
+import ./[console, math, uri]
 
-export console, math
+export console, math, uri

--- a/src/bali/stdlib/uri.nim
+++ b/src/bali/stdlib/uri.nim
@@ -1,0 +1,92 @@
+## JavaScript URI API - uses sanchar's builtin URI parser
+import std/[options, logging, tables]
+import bali/internal/sugar
+import bali/runtime/[objects, normalize]
+import mirage/ir/generator
+import mirage/atom
+import mirage/runtime/[prelude]
+import sanchar/parse/url
+import pretty
+
+const URL_FIELDS = [
+  "hostname",
+  "pathname",
+  "href",
+  "hash",
+  "host",
+  "pathname",
+  "port",
+  "protocol",
+  "searchParams"
+]
+
+var parser = newURLParser()
+
+proc transposeUrlToObject(parsed: URL, url: var MAtom, source: MAtom) =
+  when not defined(danger):
+    assert url.kind == Object, $url.kind
+
+  url.objFields["hostname"] = 0#str parsed.hostname()
+  url.objFields["pathname"] = 1#str parsed.path()
+  url.objFields["port"] = 2#integer parsed.port()
+  url.objFields["protocol"] = 3#str parsed.scheme()
+  url.objFields["searchParams"] = 4#str parsed.query()
+  url.objFields["host"] = 5#str parsed.hostname()
+  url.objFields["href"] = 6#source
+
+  url.objValues = @[
+    str parsed.hostname(),
+    str parsed.path(),
+    integer parsed.port().int,
+    str parsed.scheme(),
+    str parsed.query(),
+    str parsed.hostname(),
+    source
+  ]
+
+proc generateStdIR*(vm: PulsarInterpreter, ir: IRGenerator) =
+  info "uri: generating IR interfaces"
+
+  # `new URL()` syntax
+  vm.registerBuiltin("BALI_CONSTRUCTOR_URL",
+    proc(op: Operation) =
+      let source =
+        if vm.registers.callArgs.len > 0:
+          vm.registers.callArgs[0]
+        else:
+          null()
+
+      if source.kind != String:
+        vm.registers.retVal = some null()
+        return # TODO: TypeError
+
+      let parsed = parser.parse(&source.getStr())
+      var url = obj()
+
+      transposeUrlToObject(parsed, url, source)
+      
+      vm.registers.retVal = some(url)
+  )
+  
+  ir.newModule(normalizeIRName "URL.parse")
+  vm.registerBuiltin("BALI_URLPARSE",
+    proc(op: Operation) =
+      if vm.registers.callArgs.len < 1:
+        vm.registers.retVal = some null()
+        return
+
+      let source = vm.registers.callArgs[0]
+      
+      if source.kind != String:
+        vm.registers.retVal = some null()
+        return
+
+      var parsed = parser.parse(&source.getStr())
+
+      # allocate object
+      var url = obj()
+      transposeUrlToObject(parsed, url, source)
+
+      vm.registers.retVal = some(url)
+  )
+  ir.call("BALI_URLPARSE")

--- a/tests/runtime/thing.nim
+++ b/tests/runtime/thing.nim
@@ -1,0 +1,23 @@
+import std/[os, tables]
+import bali/grammar/prelude
+import bali/runtime/prelude
+import pretty
+import ../common
+
+enableLogging()
+var ast = newAST()
+var args: PositionedArguments
+args.pushAtom(str "https://github.com")
+
+ast.appendToCurrentScope(
+  callAndStoreMut("url", call("URL.parse", args))  
+)
+var args2: PositionedArguments
+args2.pushIdent("url")
+
+ast.appendToCurrentScope(
+  call("console.log", args2)
+)
+
+let runtime = newRuntime("t003.js", ast)
+runtime.run()


### PR DESCRIPTION
Self explanatory title. I've hit a small problem, though.

The ferus-sanchar URL parser is a bit *too* lenient, it allows any bogus string that isn't a URL to pass through, no matter how invalid it is.

Here's an example:
![image](https://github.com/user-attachments/assets/1dd40096-4fe3-4133-aab3-fe5db6967e26)
![image](https://github.com/user-attachments/assets/b56fe02b-203d-4122-bc69-3ef8a67afd69)

As you can see, that not very URL-y URL is interpreted as a URL successfully with no errors. I'll need to bring sanchar's URL parser up to the curve :sweat_smile: 