### PR TITLE
Fix compatibility with older code

### DIFF
--- a/bali.nimble
+++ b/bali.nimble
@@ -16,8 +16,7 @@ requires "pretty >= 0.1.0"
 requires "colored_logger >= 0.1.0"
 
 task balde, "Compile the Bali debugger":
-  exec "nimble uninstall bali"
-  exec "nimble install"
+  exec "nimble uninstall bali & nimble install"
 
   when defined(release):
     exec "nim c -d:release -d:speed -d:flto --out:./balde src/bali/balde.nim"

--- a/data/uri_parse.js
+++ b/data/uri_parse.js
@@ -1,2 +1,2 @@
-const url = new URL("https://github.com/ferus-web/bali")
+const url = new URL("ewr:/e!112wrnc")
 console.log(url)

--- a/src/bali/runtime/bigint/unsigned_bigint.nim
+++ b/src/bali/runtime/bigint/unsigned_bigint.nim
@@ -1,4 +1,0 @@
-## Unsigned Big Integers
-##
-## Copyright (C) 2024 Trayambak Rai and Ferus Authors
-import std/[options]


### PR DESCRIPTION
- **(add) parser now recognizes constructor syntax, URL parser properly works**
- **(fix) fix all test case compatibilities**

We've been moving really fast and breaking things equally quickly. This PR fixes all code examples from `ek.js` to `panch.js` so that they all run properly, as intended.
It also does away with the primitive internal identifier storage system in favor of a more flexible system by segregating idents as `global`, `local` and `internal`.
