### PR TITLE
Use `simdutf` instead of `std/base64` for base64 encode-decode functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ You can compile Balde, the Bali debugger by running:
 It is primarily used for debugging the engine as of right now, but it runs code fine too.
 
 # Integrating Bali into your applications
-Again, Bali is not in a usable state yet. However, it is possible to use Bali in your programs. There is no easy Nim-to-JS conversion layer yet, most of the JS code that calls Nim is using a lot of hacks and bridges provided by Mirage.
+Again, Bali is not in a usable state yet. However, it is possible to use Bali in your programs. There is no easy Nim-to-JS conversion layer yet, most of the JS code that calls Nim is using a lot of hacks and bridges provided by Mirage. \
+**Balde requires the C++ backend to be used as it depends on simdutf!**
 
 Firstly, add Bali to your project's dependencies.
 ```
@@ -48,5 +49,5 @@ runtime.run()
 # Roadmap
 - Getting a grammar to AST parser      [ X ]
 - Getting the MIR emitter working      [ X ]
-- Get arithmetic operations working    [ X ]
+- Get arithmetic operations working    [   ]
 - Getting the standard library working [   ]

--- a/bali.nimble
+++ b/bali.nimble
@@ -5,7 +5,7 @@ author        = "xTrayambak"
 description   = "The Bali JavaScript Engine"
 license       = "MIT"
 srcDir        = "src"
-
+backend       = "cpp"
 
 # Dependencies
 
@@ -14,15 +14,16 @@ requires "mirage >= 1.0.0"
 requires "librng >= 0.1.3"
 requires "pretty >= 0.1.0"
 requires "colored_logger >= 0.1.0"
+requires "simdutf >= 0.1.0"
 
 task balde, "Compile the Bali debugger":
   when defined(release):
-    exec "nim c -d:release -d:speed -d:flto --path:src --out:./balde src/bali/balde.nim"
+    exec "nim cpp -d:release -d:speed -d:flto --path:src --out:./balde src/bali/balde.nim"
   else:
     when not defined(gdb):
-      exec "nim c --out:./balde --path:src src/bali/balde.nim"
+      exec "nim cpp --out:./balde --path:src src/bali/balde.nim"
     else:
-      exec "nim c -d:useMalloc --path:src --debugger:native --profiler:on --outer:./balde src/bali/balde.nim"
+      exec "nim cpp -d:useMalloc --path:src --debugger:native --profiler:on --outer:./balde src/bali/balde.nim"
 
 task test262, "Compile the Test262 suite tester against Bali":
   when defined(release):

--- a/bali.nimble
+++ b/bali.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.0"
+version       = "0.2.1"
 author        = "xTrayambak"
 description   = "The Bali JavaScript Engine"
 license       = "MIT"

--- a/benchmarks/node-v8/basic64_speeds.sh
+++ b/benchmarks/node-v8/basic64_speeds.sh
@@ -1,0 +1,6 @@
+# Compare how fast base64 is decoded and encoded by NodeJS (V8) and Balde (Bali)
+
+echo "Compiling Balde..." &&
+nimble balde && echo "Compiled Balde successfully." &&
+time ./balde run data/b64_encode_decode.js &&
+time node data/b64_encode_decode.js

--- a/data/b64_encode_decode.js
+++ b/data/b64_encode_decode.js
@@ -1,0 +1,3 @@
+// Used for the benchmark.
+let x = btoa("Both NodeJS's base64 module and Bali's builtin base64 module use simdutf. How much do they differ in terms of speed?")
+let y = atob("QmFsaSBpcyBuZWF0LCBJIGd1ZXNzLiAoSWdub3JlIHRoZSBmYWN0IHRoYXQgYSBCYWxpIGRldmVsb3BlciB3cm90ZSB0aGlzIHRlc3Qp")

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,4 +1,7 @@
 --deepCopy:on
 
+# Bali-specific flags
+# --define:baliUseStdBase64 # Instead of simdutf's SIMD accelerated base64 encoder/decoder, use the (slower) ones in the Nim standard library.
+
 # Enable SIMD support
---passC: "-march=native -mtune=native -msse -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -mpclmul -mavx -mavx2"
+--passC: "-march=znver3 -mtune=znver3 -msse -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -mpclmul -mavx -mavx2"

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+with import <nixpkgs> { };
+
+mkShell {
+  nativeBuildInputs = [
+    pkg-config
+    simdutf
+    nodejs_22
+    quickjs
+  ];
+
+  LD_LIBRARY_PATH = lib.makeLibraryPath [
+    simdutf
+  ];
+}

--- a/src/bali/runtime/interpreter.nim
+++ b/src/bali/runtime/interpreter.nim
@@ -441,6 +441,7 @@ proc run*(runtime: Runtime) =
   math.generateStdIR(runtime.vm, runtime.ir)
   uri.generateStdIR(runtime.vm, runtime.ir)
   errors.generateStdIR(runtime.vm, runtime.ir)
+  base64.generateStdIR(runtime.vm, runtime.ir)
   parseIntGenerateStdIR(runtime.vm, runtime.ir)
 
   if runtime.opts.test262:

--- a/src/bali/stdlib/builtins/base64.nim
+++ b/src/bali/stdlib/builtins/base64.nim
@@ -1,36 +1,65 @@
 ## Base64 encoding/decoding
+## These aren't part of the ECMAScript standard, but rather the HTML living spec.
 ##
 ## Copyright (C) 2024 Trayambak Rai and Ferus Authors
-import std/[base64, logging]
+import std/[options, logging, tables]
 import mirage/ir/generator
 import mirage/runtime/prelude
 import bali/runtime/normalize
+import bali/runtime/abstract/coercion
 import bali/stdlib/errors
 import bali/internal/sugar
 import pretty
+
+when not defined(baliUseStdBase64):
+  import simdutf/base64
+else:
+  import std/base64
+  from simdutf/base64 import Base64DecodeError
 
 proc generateStdIr*(vm: PulsarInterpreter, generator: IRGenerator) =
   info "builtins.base64: generating IR interfaces"
   
   # atob
-  # Turn base64-encoded data into a normal string
+  # Decode a base64 encoded string
   generator.newModule("atob")
   vm.registerBuiltin("BALI_ATOB",
     proc(op: Operation) =
-      if op.arguments.len < 1:
+      if vm.registers.callArgs.len < 1:
         typeError(vm, "atob: At least 1 argument required, but only 0 passed")
         return
 
-      let value = op.arguments[0]
-      if value.kind != String:
-        typeError(vm, "atob: Expected String, got " & $value.kind & " instead")
-        return
-      
-      try:
-        vm.registers.retVal = decode(&value.getStr())
-      except ValueError as exc:
+      template decodeError =
         warn "atob: failed to decode string: " & exc.msg
         typeError(vm, "atob: String contains an invalid character")
         return
+
+      let
+        value = vm.RequireObjectCoercible(vm.registers.callArgs[0])
+        strVal = vm.ToString(value)
+
+      try:
+        vm.registers.retVal = some(str decode(strVal))
+      except Base64DecodeError as exc:
+        when not defined(baliUseStdBase64): decodeError
+      except ValueError as exc:
+        when defined(baliUseStdBase64): decodeError
   )
   generator.call("BALI_ATOB")
+
+  # btoa
+  # Encode a string into Base64 data
+  generator.newModule("btoa")
+  vm.registerBuiltin("BALI_BTOA",
+    proc(op: Operation) =
+      if vm.registers.callArgs.len < 1:
+        typeError(vm, "btoa: At least 1 argument required, but only 0 passed")
+        return
+
+      let 
+        value = vm.RequireObjectCoercible(vm.registers.callArgs[0])
+        str = vm.ToString(value)
+
+      vm.registers.retVal = some(str encode(str))
+  )
+  generator.call("BALI_BTOA")

--- a/src/bali/stdlib/errors.nim
+++ b/src/bali/stdlib/errors.nim
@@ -25,12 +25,19 @@ proc jsException*(msg: string): JSException {.inline.} =
 
   exc
 
+proc logTracebackAndDie*(vm: PulsarInterpreter) =
+  let traceback = vm.generateTraceback()
+  assert *traceback, "Mirage failed to generate traceback!"
+
+  stderr.write &traceback & '\n'
+  quit(1)
+
 proc typeError*(vm: PulsarInterpreter, message: string) {.inline.} =
   ## Meant for other Bali stdlib methods to use.
   vm.throw(
-    jsException("Uncaught TypeError: " & message)
+    jsException("TypeError: " & message)
   )
-  quit(1)
+  vm.logTracebackAndDie()
 
 proc generateStdIr*(vm: PulsarInterpreter, ir: IRGenerator) =
   info "errors: generate IR interface"
@@ -40,10 +47,5 @@ proc generateStdIr*(vm: PulsarInterpreter, ir: IRGenerator) =
       vm.throw(
         jsException(&vm.registers.callArgs[0].getStr())
       )
-      
-      let traceback = vm.generateTraceback()
-      assert *traceback, "Mirage failed to generate traceback!"
-
-      echo &traceback
-      quit(1)
+      vm.logTracebackAndDie()
   )

--- a/src/bali/stdlib/prelude.nim
+++ b/src/bali/stdlib/prelude.nim
@@ -1,4 +1,4 @@
 import ./[console, math, uri, errors]
-import ./builtins/[parse_int, test262]
+import ./builtins/[base64, parse_int, test262]
 
-export console, math, uri, parse_int, errors, test262
+export console, math, uri, parse_int, errors, test262, base64


### PR DESCRIPTION
I have bound `simdutf` to Nim and made it a Nimble package.

Unrelated, but we now pass 1.2% of the Test262 suite :^)