### PR TITLE
Add better interoperability interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,27 @@ while (commitsToBali < 2000) {
     commitsToBali++
     console.log(commitsToBali)
 }
+
+let lemonade = fetchLemonade(4)
+console.log(lemonade)
 """
 
 let 
   parser = newParser(JS_SRC) # Feed your JavaScript code to Bali's JavaScript parser
   ast = parser.parse() # Parse an AST out of the tokens
   runtime = newRuntime("myfile.js", ast) # Instantiate the JavaScript runtime.
+
+# define a native function which is exposed to the JavaScript code
+runtime.defineFn(
+    "fetchLemonade",
+    proc =
+      let num = runtime.ToNumber(&runtime.argument(1))
+
+      if num == 0 or num > 1:
+        ret str("You have " & $num & " lemonades!")
+      else:
+        ret str("You have a lemonade!")
+)
 
 # Emit Mirage bytecode and pass over control to the Mirage VM.
 # NOTE: This is a blocking function and will block this thread until execution is completed (or an error is encountered and the

--- a/src/bali/grammar/parser.nim
+++ b/src/bali/grammar/parser.nim
@@ -793,7 +793,7 @@ proc parseStatement*(parser: Parser, inFnBody: bool = false): Option[Statement] 
     discard
   of TokenKind.Shebang:
     if inFnBody:
-      parser.error Other, "shebang is not allowed inside of a function body"
+      parser.error Other, "shebangs are not allowed inside of a function body"
 
     if parser.foundShebang:
       parser.error Other, "one file cannot have two shebangs"

--- a/src/bali/grammar/parser.nim
+++ b/src/bali/grammar/parser.nim
@@ -721,6 +721,9 @@ proc parseStatement*(parser: Parser, inFnBody: bool = false): Option[Statement] 
     parser.tokenizer.pos = prevPos
     parser.tokenizer.location = prevLoc
   of TokenKind.Return:
+    if not inFnBody:
+      parser.error Other, "return not in function"
+
     let
       prevPos = parser.tokenizer.pos
       prevLoc = parser.tokenizer.location

--- a/src/bali/grammar/tokenizer.nim
+++ b/src/bali/grammar/tokenizer.nim
@@ -439,8 +439,9 @@ proc consumeMinus*(tokenizer: Tokenizer): Token =
     of '-':
       debug "tokenizer: minus sign is followed by another one, consuming Decrement"
       return Token(kind: TokenKind.Decrement)
-    else: discard
-  
+    else:
+      discard
+
   tokenizer.advance()
   debug "tokenizer: minus sign is not followed by another minus, consuming Sub"
   return Token(kind: TokenKind.Sub)

--- a/src/bali/runtime/abstract/coercible.nim
+++ b/src/bali/runtime/abstract/coercible.nim
@@ -1,6 +1,6 @@
 import std/[logging]
 import mirage/runtime/prelude
-import bali/runtime/atom_helpers
+import bali/runtime/[atom_helpers, types]
 import bali/stdlib/errors
 
 proc RequireObjectCoercible*(vm: PulsarInterpreter, value: MAtom): MAtom {.inline.} =
@@ -9,3 +9,6 @@ proc RequireObjectCoercible*(vm: PulsarInterpreter, value: MAtom): MAtom {.inlin
     return
 
   value
+
+proc RequireObjectCoercible*(runtime: Runtime, value: MAtom): MAtom {.inline.} =
+  runtime.vm.RequireObjectCoercible(value)

--- a/src/bali/runtime/abstract/to_number.nim
+++ b/src/bali/runtime/abstract/to_number.nim
@@ -1,12 +1,11 @@
 import std/[logging]
 import mirage/runtime/prelude
 import bali/internal/sugar
-import bali/runtime/atom_helpers
+import bali/runtime/[atom_helpers, types]
 import bali/stdlib/errors
 import bali/internal/[trim_string, parse_number]
 
 proc StringToNumber*(vm: PulsarInterpreter, value: MAtom): float =
-  # FIXME: non-compliant
   assert value.kind == String, "StringToNumber() was passed a " & $value.kind
   debug "runtime: StringToNumber(" & value.crush() & ')'
   let text = vm.trimString(value, TrimMode.Both)
@@ -53,3 +52,6 @@ proc ToNumber*(vm: PulsarInterpreter, value: MAtom): float =
     return vm.StringToNumber(value)
   else:
     unreachable
+
+proc ToNumber*(runtime: Runtime, value: MAtom): float {.inline.} =
+  runtime.vm.ToNumber(value)

--- a/src/bali/runtime/abstract/to_string.nim
+++ b/src/bali/runtime/abstract/to_string.nim
@@ -1,10 +1,10 @@
 import std/[logging]
 import mirage/runtime/prelude
 import bali/internal/sugar
-import bali/runtime/atom_helpers
+import bali/runtime/[atom_helpers, types]
 import bali/stdlib/errors
 
-proc ToString*(vm: PulsarInterpreter, value: MAtom): string {.inline.} =
+proc ToString*(vm: PulsarInterpreter, value: MAtom): string =
   ## 7.1.17 ToString ( argument )
   ## The abstract operation ToString takes argument argument (an ECMAScript language value) and returns either a normal completion containing a String or a throw completion. It converts argument to a value of type String. It performs the following steps when called
   debug "runtime: toString(): " & value.crush()
@@ -58,3 +58,6 @@ proc ToString*(vm: PulsarInterpreter, value: MAtom): string {.inline.} =
     buffer &= ']'
 
     return buffer
+
+proc ToString*(runtime: Runtime, value: MAtom): string {.inline.} =
+  runtime.vm.ToString(value)

--- a/src/bali/runtime/arguments.nim
+++ b/src/bali/runtime/arguments.nim
@@ -33,10 +33,7 @@ proc argument*(
   some(vm.registers.callArgs[position - 1])
 
 proc argument*(
-  runtime: Runtime,
-  position: Natural,
-  required: bool = false,
-  message: string = ""
+    runtime: Runtime, position: Natural, required: bool = false, message: string = ""
 ): Option[MAtom] {.inline.} =
   ## Get an argument from the call arguments register.
   ## If `required` is `true`, then a TypeError with an error message of your choice will be thrown.

--- a/src/bali/runtime/arguments.nim
+++ b/src/bali/runtime/arguments.nim
@@ -1,7 +1,7 @@
 import std/[logging, options, strutils]
 import mirage/atom
 import mirage/runtime/pulsar/interpreter
-import bali/runtime/atom_helpers
+import bali/runtime/[atom_helpers, types]
 import bali/stdlib/errors
 
 proc argument*(
@@ -10,12 +10,7 @@ proc argument*(
     required: bool = false,
     message: string = "",
 ): Option[MAtom] =
-  ## Get an argument from the call arguments register.
-  ## If `required` is `true`, then a TypeError with an error message of your choice will be thrown.
-  ## This routine is guaranteed to return a value when `required` is set to `false`, which it is by default.
-  ##
-  ## Error message substitutions:
-  ## `{nargs}` - the number of arguments currently in the call arguments register
+  ## Internal method
   assert(position > 0, "argument() only accepts naturals.")
   debug "runtime: fetching argument #" & $position
 
@@ -36,3 +31,17 @@ proc argument*(
       return some(undefined())
 
   some(vm.registers.callArgs[position - 1])
+
+proc argument*(
+  runtime: Runtime,
+  position: Natural,
+  required: bool = false,
+  message: string = ""
+): Option[MAtom] {.inline.} =
+  ## Get an argument from the call arguments register.
+  ## If `required` is `true`, then a TypeError with an error message of your choice will be thrown.
+  ## This routine is guaranteed to return a value when `required` is set to `false`, which it is by default.
+  ##
+  ## Error message substitutions:
+  ## `{nargs}` - the number of arguments currently in the call arguments register
+  runtime.vm.argument(position = position, required = required, message = message)

--- a/src/bali/runtime/interpreter.nim
+++ b/src/bali/runtime/interpreter.nim
@@ -776,9 +776,9 @@ proc generateInternalIR*(runtime: Runtime) =
   runtime.ir.call("BALI_RESOLVEFIELD_INTERNAL")
 
 proc run*(runtime: Runtime) =
-  console.generateStdIR(runtime.vm, runtime.ir)
+  console.generateStdIR(runtime)
   math.generateStdIR(runtime)
-  uri.generateStdIR(runtime.vm, runtime.ir)
+  uri.generateStdIR(runtime)
   errors.generateStdIR(runtime.vm, runtime.ir)
   base64.generateStdIR(runtime.vm, runtime.ir)
   json.generateStdIR(runtime.vm, runtime.ir)

--- a/src/bali/runtime/interpreter.nim
+++ b/src/bali/runtime/interpreter.nim
@@ -777,7 +777,7 @@ proc generateInternalIR*(runtime: Runtime) =
 
 proc run*(runtime: Runtime) =
   console.generateStdIR(runtime.vm, runtime.ir)
-  math.generateStdIR(runtime.vm, runtime.ir)
+  math.generateStdIR(runtime)
   uri.generateStdIR(runtime.vm, runtime.ir)
   errors.generateStdIR(runtime.vm, runtime.ir)
   base64.generateStdIR(runtime.vm, runtime.ir)

--- a/src/bali/runtime/interpreter.nim
+++ b/src/bali/runtime/interpreter.nim
@@ -780,8 +780,8 @@ proc run*(runtime: Runtime) =
   math.generateStdIR(runtime)
   uri.generateStdIR(runtime)
   errors.generateStdIR(runtime.vm, runtime.ir)
-  base64.generateStdIR(runtime.vm, runtime.ir)
-  json.generateStdIR(runtime.vm, runtime.ir)
+  base64.generateStdIR(runtime)
+  json.generateStdIR(runtime)
   parseIntGenerateStdIR(runtime.vm, runtime.ir)
   constants.generateStdIR(runtime)
 

--- a/src/bali/runtime/prelude.nim
+++ b/src/bali/runtime/prelude.nim
@@ -1,4 +1,5 @@
 import mirage/atom
 import ./[interpreter, atom_helpers, arguments]
+import ./abstract/coercion
 
-export atom, interpreter, atom_helpers, arguments
+export atom, interpreter, atom_helpers, arguments, coercion

--- a/src/bali/runtime/types.nim
+++ b/src/bali/runtime/types.nim
@@ -130,8 +130,27 @@ proc defineFn*(runtime: Runtime, name: string, fn: NativeFunction) =
   )
   runtime.ir.call(builtinName)
 
+proc defineConstructor*(
+  runtime: Runtime,
+  name: string,
+  fn: NativeFunction
+) {.inline.} =
+  debug "runtime: exposing constructor for type: " & name
+  ## Expose a constructor for a type to a JavaScript runtime.
+  runtime.vm.registerBuiltin(
+    "BALI_CONSTRUCTOR_" & name,
+    proc(_: Operation) =
+      fn()
+  )
+
 template ret*(atom: MAtom) =
   ## Shorthand for:
   ## ..code-block:: Nim
   ##  runtime.vm.registers.retVal = some(atom)
+  ##  return
   runtime.vm.registers.retVal = some(atom)
+  return
+
+func argumentCount*(runtime: Runtime): int {.inline.} =
+  ## Get the number of atoms in the `CallArgs` register
+  runtime.vm.registers.callArgs.len

--- a/src/bali/runtime/types.nim
+++ b/src/bali/runtime/types.nim
@@ -4,7 +4,7 @@ import std/[options, hashes, logging, strutils]
 import mirage/ir/generator
 import mirage/runtime/prelude
 import bali/grammar/prelude
-import bali/runtime/normalize
+import bali/runtime/[normalize]
 
 type
   NativeFunction* = proc()

--- a/src/bali/runtime/types.nim
+++ b/src/bali/runtime/types.nim
@@ -1,11 +1,14 @@
 ## Runtime types
 ## Copyright (C) 2024 Trayambak Rai and Ferus Authors
-import std/[options, hashes, logging]
+import std/[options, hashes, logging, strutils]
 import mirage/ir/generator
 import mirage/runtime/prelude
 import bali/grammar/prelude
+import bali/runtime/normalize
 
 type
+  NativeFunction* = proc()
+
   ValueKind* = enum
     vkGlobal
     vkLocal
@@ -114,3 +117,21 @@ proc markLocal*(runtime: Runtime, fn: Function, ident: string) =
   info "Ident \"" & ident & "\" is being locally marked at index " & $runtime.addrIdx
 
   inc runtime.addrIdx
+
+proc defineFn*(runtime: Runtime, name: string, fn: NativeFunction) =
+  ## Expose a native function to a JavaScript runtime.
+  debug "runtime: exposing native function to runtime: " & name
+  runtime.ir.newModule(normalizeIRName name)
+  let builtinName = "BALI_" & toUpperAscii(normalizeIRName(name))
+  runtime.vm.registerBuiltin(
+    builtinName,
+    proc(_: Operation) =
+      fn()
+  )
+  runtime.ir.call(builtinName)
+
+template ret*(atom: MAtom) =
+  ## Shorthand for:
+  ## ..code-block:: Nim
+  ##  runtime.vm.registers.retVal = some(atom)
+  runtime.vm.registers.retVal = some(atom)

--- a/src/bali/runtime/types.nim
+++ b/src/bali/runtime/types.nim
@@ -126,21 +126,17 @@ proc defineFn*(runtime: Runtime, name: string, fn: NativeFunction) =
   runtime.vm.registerBuiltin(
     builtinName,
     proc(_: Operation) =
-      fn()
+      fn(),
   )
   runtime.ir.call(builtinName)
 
-proc defineConstructor*(
-  runtime: Runtime,
-  name: string,
-  fn: NativeFunction
-) {.inline.} =
+proc defineConstructor*(runtime: Runtime, name: string, fn: NativeFunction) {.inline.} =
   debug "runtime: exposing constructor for type: " & name
   ## Expose a constructor for a type to a JavaScript runtime.
   runtime.vm.registerBuiltin(
     "BALI_CONSTRUCTOR_" & name,
     proc(_: Operation) =
-      fn()
+      fn(),
   )
 
 template ret*(atom: MAtom) =

--- a/src/bali/stdlib/builtins/base64.nim
+++ b/src/bali/stdlib/builtins/base64.nim
@@ -25,7 +25,7 @@ proc generateStdIr*(runtime: Runtime) =
   # Decode a base64 encoded string
   runtime.defineFn(
     "atob",
-    proc =
+    proc() =
       if runtime.argumentCount() < 1:
         typeError(runtime.vm, "atob: At least 1 argument required, but only 0 passed")
         return
@@ -42,17 +42,24 @@ proc generateStdIr*(runtime: Runtime) =
       try:
         ret str decode(strVal)
       except Base64DecodeError as exc:
-        decodeError
+        decodeError,
   )
 
   # btoa
   # Encode a string into Base64 data
   runtime.defineFn(
     "btoa",
-    proc =
+    proc() =
       let
-        value = runtime.RequireObjectCoercible(&runtime.argument(1, required = true, message = "btoa: At least 1 argument required, but only {nargs} passed"))
+        value = runtime.RequireObjectCoercible(
+          &runtime.argument(
+            1,
+            required = true,
+            message = "btoa: At least 1 argument required, but only {nargs} passed",
+          )
+        )
         str = runtime.ToString(value)
 
       ret str encode(str)
+    ,
   )

--- a/src/bali/stdlib/console.nim
+++ b/src/bali/stdlib/console.nim
@@ -44,31 +44,31 @@ proc consoleLogIR*(runtime: Runtime) =
   # Perform Logger("log", data).
   runtime.defineFn(
     "console.log",
-    proc =
-      console(runtime, ConsoleLevel.Log)
+    proc() =
+      console(runtime, ConsoleLevel.Log),
   )
 
   # console.warn
   # Perform Logger("warn", data).
   runtime.defineFn(
     "console.warn",
-    proc =
-      console(runtime, ConsoleLevel.Warn)
+    proc() =
+      console(runtime, ConsoleLevel.Warn),
   )
 
   # console.info
   # Perform Logger("info", data).
   runtime.defineFn(
     "console.info",
-    proc =
-      console(runtime, ConsoleLevel.Info)
+    proc() =
+      console(runtime, ConsoleLevel.Info),
   )
 
   # console.error
   # Perform Logger("error", data).
   runtime.defineFn(
     "console.error",
-    proc =
+    proc() =
       console(runtime, ConsoleLevel.Error),
   )
 
@@ -76,7 +76,7 @@ proc consoleLogIR*(runtime: Runtime) =
   # Perform Logger("debug", data).
   runtime.defineFn(
     "console.debug",
-    proc =
+    proc() =
       console(runtime, ConsoleLevel.Debug),
   )
 

--- a/src/bali/stdlib/json.nim
+++ b/src/bali/stdlib/json.nim
@@ -75,7 +75,7 @@ proc generateStdIR*(runtime: Runtime) =
   ## This function parses a JSON text (a JSON-formatted String) and produces an ECMAScript language value. The JSON format represents literals, arrays, and objects with a syntax similar to the syntax for ECMAScript literals, Array Initializers, and Object Initializers. After parsing, JSON objects are realized as ECMAScript objects. JSON arrays are realized as ECMAScript Array instances. JSON strings, numbers, booleans, and null are realized as ECMAScript Strings, Numbers, Booleans, and null.
   runtime.defineFn(
     "JSON.parse",
-    proc =
+    proc() =
       # 1. Let jsonString be ? ToString(text).
       let jsonString =
         if runtime.argumentCount() != 0:
@@ -92,6 +92,7 @@ proc generateStdIR*(runtime: Runtime) =
 
       let atom = convertJsonNodeToAtom(parsed)
       ret atom
+    ,
   )
 
   ## 25.5.2 JSON.stringify ( value [ , replacer [ , space ] ] )
@@ -99,10 +100,11 @@ proc generateStdIR*(runtime: Runtime) =
   ## This function returns a String in UTF-16 encoded JSON format representing an ECMAScript language value, or undefined. It can take three parameters. The value parameter is an ECMAScript language value, which is usually an object or array, although it can also be a String, Boolean, Number or null. The optional replacer parameter is either a function that alters the way objects and arrays are stringified, or an array of Strings and Numbers that acts as an inclusion list for selecting the object properties that will be stringified. The optional space parameter is a String or Number that allows the result to have white space injected into it to improve human readability.
   runtime.defineFn(
     "JSON.stringify",
-    proc =
+    proc() =
       let
         atom = &runtime.argument(1)
         node = atomToJsonNode(atom)
 
       ret str(pretty node)
+    ,
   )

--- a/src/bali/stdlib/json.nim
+++ b/src/bali/stdlib/json.nim
@@ -2,7 +2,7 @@
 ## Copyright (C) 2024 Trayambak Rai and Ferus Authors
 import std/[json, options, logging, tables]
 import bali/internal/sugar
-import bali/runtime/[objects, normalize, atom_helpers, arguments]
+import bali/runtime/[objects, normalize, atom_helpers, arguments, types]
 import bali/runtime/abstract/coercion
 import bali/stdlib/errors
 import mirage/ir/generator
@@ -68,45 +68,41 @@ proc atomToJsonNode*(atom: MAtom): JsonNode =
 
   newJNull()
 
-proc generateStdIR*(vm: PulsarInterpreter, ir: IRGenerator) =
+proc generateStdIR*(runtime: Runtime) =
   info "json: generating IR interfaces"
 
-  ir.newModule(normalizeIRName "JSON.parse")
   ## 25.5.1 JSON.parse ( text [ , reviver ] )
   ## This function parses a JSON text (a JSON-formatted String) and produces an ECMAScript language value. The JSON format represents literals, arrays, and objects with a syntax similar to the syntax for ECMAScript literals, Array Initializers, and Object Initializers. After parsing, JSON objects are realized as ECMAScript objects. JSON arrays are realized as ECMAScript Array instances. JSON strings, numbers, booleans, and null are realized as ECMAScript Strings, Numbers, Booleans, and null.
-  vm.registerBuiltin(
-    "BALI_JSONPARSE",
-    proc(op: Operation) =
+  runtime.defineFn(
+    "JSON.parse",
+    proc =
       # 1. Let jsonString be ? ToString(text).
       let jsonString =
-        if vm.registers.callArgs.len != 0:
-          vm.ToString(vm.registers.callArgs[0])
+        if runtime.argumentCount() != 0:
+          runtime.ToString(&runtime.argument(1))
         else:
-          ""
+          newString(0)
 
       let parsed =
         try:
           fromJson(jsonString)
         except jsony.JsonError as exc:
-          vm.syntaxError(exc.msg)
+          runtime.vm.syntaxError(exc.msg)
           JsonNode()
 
       let atom = convertJsonNodeToAtom(parsed)
-      vm.registers.retVal = some(atom),
+      ret atom
   )
-  ir.call("BALI_JSONPARSE")
 
-  ir.newModule(normalizeIRName "JSON.stringify")
   ## 25.5.2 JSON.stringify ( value [ , replacer [ , space ] ] )
   # FIXME: not compliant yet!
   ## This function returns a String in UTF-16 encoded JSON format representing an ECMAScript language value, or undefined. It can take three parameters. The value parameter is an ECMAScript language value, which is usually an object or array, although it can also be a String, Boolean, Number or null. The optional replacer parameter is either a function that alters the way objects and arrays are stringified, or an array of Strings and Numbers that acts as an inclusion list for selecting the object properties that will be stringified. The optional space parameter is a String or Number that allows the result to have white space injected into it to improve human readability.
-  vm.registerBuiltin(
-    "BALI_JSONSTRINGIFY",
-    proc(op: Operation) =
+  runtime.defineFn(
+    "JSON.stringify",
+    proc =
       let
-        atom = &vm.argument(0)
+        atom = &runtime.argument(1)
         node = atomToJsonNode(atom)
 
-      vm.registers.retVal = some(str(pretty node)),
+      ret str(pretty node)
   )
-  ir.call("BALI_JSONSTRINGIFY")

--- a/src/bali/stdlib/math.nim
+++ b/src/bali/stdlib/math.nim
@@ -35,146 +35,162 @@ proc generateStdIr*(runtime: Runtime) =
   # number generation algorithms that librng implements!
   runtime.defineFn(
     "Math.random",
-    proc =
+    proc() =
       let value = float64(rng.generator.next()) / 1.8446744073709552e+19'f64
       ret floating(value)
+    ,
   )
 
   # Math.pow
   runtime.defineFn(
     "Math.pow",
-    proc =
+    proc() =
       let
         value = runtime.ToNumber(&runtime.argument(1))
         exponent = runtime.ToNumber(&runtime.argument(2))
 
       ret floating pow(value, exponent)
+    ,
   )
 
   # Math.cos
   runtime.defineFn(
     "Math.cos",
-    proc =
+    proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
       ret floating cos(value)
+    ,
   )
 
   # Math.sqrt
   runtime.defineFn(
     "Math.sqrt",
-    proc =
+    proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
       ret floating sqrt(value)
+    ,
   )
 
   # Math.tanh
   runtime.defineFn(
     "Math.tanh",
-    proc =
+    proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
       ret floating tanh(value)
+    ,
   )
 
   # Math.sin
   runtime.defineFn(
     "Math.sin",
-    proc =
+    proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
       ret floating sin(value)
+    ,
   )
 
   # Math.sinh
   runtime.defineFn(
     "Math.sinh",
-    proc =
+    proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
       ret floating sinh(value)
+    ,
   )
 
   # Math.tan
   runtime.defineFn(
     "Math.tan",
-    proc =
+    proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
       ret floating tan(value)
+    ,
   )
 
   # Math.trunc
   runtime.defineFn(
     "Math.trunc",
-    proc =
+    proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
       ret floating trunc(value)
+    ,
   )
 
   # Math.floor
   runtime.defineFn(
     "Math.floor",
-    proc =
+    proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
       ret floating floor(value)
+    ,
   )
 
   # Math.ceil
   runtime.defineFn(
     "Math.ceil",
-    proc =
+    proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
       ret floating ceil(value)
+    ,
   )
 
   # Math.cbrt
   runtime.defineFn(
     "Math.cbrt",
-    proc =
+    proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
       ret floating cbrt(value)
+    ,
   )
 
   # Math.log
   runtime.defineFn(
     "Math.log",
-    proc =
+    proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
       ret floating ln(value)
+    ,
   )
 
   # Math.abs
   runtime.defineFn(
     "Math.abs",
-    proc =
+    proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
       ret floating abs(value)
+    ,
   )
 
   # Math.max
   runtime.defineFn(
     "Math.max",
-    proc =
-      let 
+    proc() =
+      let
         a = runtime.ToNumber(&runtime.argument(1))
         b = runtime.ToNumber(&runtime.argument(2))
 
       ret floating max(a, b)
+    ,
   )
 
   # Math.min
   runtime.defineFn(
     "Math.min",
-    proc =
-      let 
+    proc() =
+      let
         a = runtime.ToNumber(&runtime.argument(1))
         b = runtime.ToNumber(&runtime.argument(2))
 
       ret floating min(a, b)
+    ,
   )

--- a/src/bali/stdlib/math.nim
+++ b/src/bali/stdlib/math.nim
@@ -3,7 +3,7 @@
 import std/[importutils, tables, math, options, logging]
 import mirage/ir/generator
 import mirage/runtime/prelude
-import bali/runtime/[normalize]
+import bali/runtime/[normalize, arguments, types]
 import bali/runtime/abstract/[to_number]
 import bali/internal/sugar
 import pretty, librng, librng/generator
@@ -27,164 +27,154 @@ let Algorithm =
 # Global RNG source
 var rng = newRNG(algo = Algorithm)
 
-proc generateStdIr*(vm: PulsarInterpreter, generator: IRGenerator) =
+proc generateStdIr*(runtime: Runtime) =
   info "math: generating IR interfaces"
 
   # Math.random
   # WARN: Do not use this for cryptography! This uses one of eight highly predictable pseudo-random
   # number generation algorithms that librng implements!
-  generator.newModule(normalizeIRName "Math.random")
-  vm.registerBuiltin(
-    "BALI_MATHRANDOM",
-    proc(op: Operation) =
+  runtime.defineFn(
+    "Math.random",
+    proc =
       let value = float64(rng.generator.next()) / 1.8446744073709552e+19'f64
-
-      vm.registers.retVal = some floating value,
+      ret floating(value)
   )
-  generator.call("BALI_MATHRANDOM")
 
   # Math.pow
-  generator.newModule(normalizeIRName "Math.pow")
-  vm.registerBuiltin(
-    "BALI_MATHPOW",
-    proc(op: Operation) =
+  runtime.defineFn(
+    "Math.pow",
+    proc =
       let
-        value = vm.ToNumber(vm.registers.callArgs[0])
-        exponent = vm.ToNumber(vm.registers.callArgs[1])
+        value = runtime.ToNumber(&runtime.argument(1))
+        exponent = runtime.ToNumber(&runtime.argument(2))
 
-      vm.registers.retVal = some floating pow(value, exponent),
+      ret floating pow(value, exponent)
   )
-  generator.call("BALI_MATHPOW")
 
   # Math.cos
-  generator.newModule(normalizeIRName "Math.cos")
-  vm.registerBuiltin(
-    "BALI_MATHCOS",
-    proc(op: Operation) =
-      let value = vm.ToNumber(vm.registers.callArgs[0])
-
-      vm.registers.retVal = some floating cos(value),
+  runtime.defineFn(
+    "Math.cos",
+    proc =
+      let value = runtime.ToNumber(&runtime.argument(1))
+      ret floating cos(value)
   )
-  generator.call("BALI_MATHCOS")
 
   # Math.sqrt
-  generator.newModule(normalizeIRName "Math.sqrt")
-  vm.registerBuiltin(
-    "BALI_MATHSQRT",
-    proc(op: Operation) =
-      let value = vm.ToNumber(vm.registers.callArgs[0])
-
-      vm.registers.retVal = some floating sqrt(value),
+  runtime.defineFn(
+    "Math.sqrt",
+    proc =
+      let value = runtime.ToNumber(&runtime.argument(1))
+      ret floating sqrt(value)
   )
-  generator.call("BALI_MATHSQRT")
 
   # Math.tanh
-  generator.newModule(normalizeIRName "Math.tanh")
-  vm.registerBuiltin(
-    "BALI_MATHTANH",
-    proc(op: Operation) =
-      let value = vm.ToNumber(vm.registers.callArgs[0])
+  runtime.defineFn(
+    "Math.tanh",
+    proc =
+      let value = runtime.ToNumber(&runtime.argument(1))
 
-      vm.registers.retVal = some floating tanh(value),
+      ret floating tanh(value)
   )
-  generator.call("BALI_MATHTANH")
 
   # Math.sin
-  generator.newModule(normalizeIRName "Math.sin")
-  vm.registerBuiltin(
-    "BALI_MATHSIN",
-    proc(op: Operation) =
-      let value = vm.ToNumber(vm.registers.callArgs[0])
+  runtime.defineFn(
+    "Math.sin",
+    proc =
+      let value = runtime.ToNumber(&runtime.argument(1))
 
-      vm.registers.retVal = some floating sin(value),
+      ret floating sin(value)
   )
-  generator.call("BALI_MATHSIN")
 
   # Math.sinh
-  generator.newModule(normalizeIRName "Math.sinh")
-  vm.registerBuiltin(
-    "BALI_MATHSINH",
-    proc(op: Operation) =
-      let value = vm.ToNumber(vm.registers.callArgs[0])
+  runtime.defineFn(
+    "Math.sinh",
+    proc =
+      let value = runtime.ToNumber(&runtime.argument(1))
 
-      vm.registers.retVal = some floating sinh(value),
+      ret floating sinh(value)
   )
-  generator.call("BALI_MATHSINH")
 
   # Math.tan
-  generator.newModule(normalizeIRName "Math.tan")
-  vm.registerBuiltin(
-    "BALI_MATHTAN",
-    proc(op: Operation) =
-      let value = vm.ToNumber(vm.registers.callArgs[0])
+  runtime.defineFn(
+    "Math.tan",
+    proc =
+      let value = runtime.ToNumber(&runtime.argument(1))
 
-      vm.registers.retVal = some floating tan(value),
+      ret floating tan(value)
   )
-  generator.call("BALI_MATHTAN")
 
   # Math.trunc
-  generator.newModule(normalizeIRName "Math.trunc")
-  vm.registerBuiltin(
-    "BALI_MATHTRUNC",
-    proc(op: Operation) =
-      let value = vm.ToNumber(vm.registers.callArgs[0])
+  runtime.defineFn(
+    "Math.trunc",
+    proc =
+      let value = runtime.ToNumber(&runtime.argument(1))
 
-      vm.registers.retVal = some floating trunc(value),
+      ret floating trunc(value)
   )
-  generator.call("BALI_MATHTRUNC")
 
   # Math.floor
-  generator.newModule(normalizeIRName "Math.floor")
-  vm.registerBuiltin(
-    "BALI_MATHFLOOR",
-    proc(op: Operation) =
-      let value = vm.ToNumber(vm.registers.callArgs[0])
+  runtime.defineFn(
+    "Math.floor",
+    proc =
+      let value = runtime.ToNumber(&runtime.argument(1))
 
-      vm.registers.retVal = some floating floor(value),
+      ret floating floor(value)
   )
-  generator.call("BALI_MATHFLOOR")
 
   # Math.ceil
-  generator.newModule(normalizeIRName "Math.ceil")
-  vm.registerBuiltin(
-    "BALI_MATHCEIL",
-    proc(op: Operation) =
-      let value = vm.ToNumber(vm.registers.callArgs[0])
-      vm.registers.retVal = some floating ceil(value),
+  runtime.defineFn(
+    "Math.ceil",
+    proc =
+      let value = runtime.ToNumber(&runtime.argument(1))
+
+      ret floating ceil(value)
   )
-  generator.call("BALI_MATHCEIL")
 
   # Math.cbrt
-  generator.newModule(normalizeIRName "Math.cbrt")
-  vm.registerBuiltin(
-    "BALI_MATHCBRT",
-    proc(op: Operation) =
-      let value = vm.ToNumber(vm.registers.callArgs[0])
+  runtime.defineFn(
+    "Math.cbrt",
+    proc =
+      let value = runtime.ToNumber(&runtime.argument(1))
 
-      vm.registers.retVal = some floating cbrt(value),
+      ret floating cbrt(value)
   )
-  generator.call("BALI_MATHCBRT")
 
   # Math.log
-  generator.newModule(normalizeIRName "Math.max")
-  vm.registerBuiltin(
-    "BALI_MATHMAX",
-    proc(op: Operation) =
-      let
-        a = vm.ToNumber(vm.registers.callArgs[0])
-        b = vm.ToNumber(vm.registers.callArgs[1])
+  runtime.defineFn(
+    "Math.log",
+    proc =
+      let value = runtime.ToNumber(&runtime.argument(1))
 
-      vm.registers.retVal = some floating max(a, b),
+      ret floating ln(value)
   )
-  generator.call("BALI_MATHMAX")
 
   # Math.abs
-  generator.newModule(normalizeIRName "Math.abs")
-  vm.registerBuiltin(
-    "BALI_MATHABS",
-    proc(op: Operation) =
-      let value = vm.ToNumber(vm.registers.callArgs[0])
+  runtime.defineFn(
+    "Math.abs",
+    proc =
+      let value = runtime.ToNumber(&runtime.argument(1))
 
-      vm.registers.retVal = some floating abs(value),
+      ret floating abs(value)
   )
-  generator.call("BALI_MATHABS")
+
+  # Math.max
+  runtime.defineFn(
+    "Math.max",
+    proc =
+      let 
+        a = runtime.ToNumber(&runtime.argument(1))
+        b = runtime.ToNumber(&runtime.argument(2))
+
+      ret floating max(a, b)
+  )
+
+  # Math.min
+  runtime.defineFn(
+    "Math.min",
+    proc =
+      let 
+        a = runtime.ToNumber(&runtime.argument(1))
+        b = runtime.ToNumber(&runtime.argument(2))
+
+      ret floating min(a, b)
+  )

--- a/src/bali/stdlib/uri.nim
+++ b/src/bali/stdlib/uri.nim
@@ -1,7 +1,7 @@
 ## JavaScript URL API - uses sanchar's builtin URL parser
 import std/[options, logging, tables]
 import bali/internal/sugar
-import bali/runtime/[objects, normalize, arguments]
+import bali/runtime/[objects, normalize, arguments, types]
 import bali/runtime/abstract/coercion
 import bali/stdlib/errors
 import mirage/ir/generator
@@ -41,17 +41,17 @@ proc transposeUrlToObject(parsed: URL, url: var MAtom, source: MAtom) =
       else: str newString(0)),
     ]
 
-proc generateStdIR*(vm: PulsarInterpreter, ir: IRGenerator) =
+proc generateStdIR*(runtime: Runtime) =
   info "url: generating IR interfaces"
 
-  # `new URL()` syntax
-  vm.registerBuiltin(
-    "BALI_CONSTRUCTOR_URL",
-    proc(op: Operation) =
+  # URL constructor (`new URL()` syntax)
+  runtime.defineConstructor(
+    "URL",
+    proc =
       var osource: Option[MAtom]
 
       if (;
-        osource = vm.argument(
+        osource = runtime.argument(
           1, true,
           "URL constructor: At least 1 argument required, but only {nargs} passed",
         )
@@ -62,19 +62,19 @@ proc generateStdIR*(vm: PulsarInterpreter, ir: IRGenerator) =
       let source = &move(osource)
 
       if source.kind != String:
-        vm.typeError(
-          "URL constructor: " & ToString(vm, source) & " is not a valid URL."
+        runtime.vm.typeError(
+          "URL constructor: " & runtime.ToString(source) & " is not a valid URL."
         )
         return
 
       let parsed =
         try:
-          parser.parse(ToString(vm, source))
+          parser.parse(runtime.ToString(source))
         except URLParseError as pError:
           debug "url: encountered parse error whilst parsing url: " & &source.getStr() &
             ": " & pError.msg
           debug "url: this is a constructor, so a TypeError will be thrown."
-          vm.typeError(pError.msg)
+          runtime.vm.typeError(pError.msg)
           newURL("", "", "", "")
             # unreachable, no need to worry. this just exists to make the compiler happy.
 
@@ -85,21 +85,17 @@ proc generateStdIR*(vm: PulsarInterpreter, ir: IRGenerator) =
 
       transposeUrlToObject(parsed, url, source)
 
-      vm.registers.retVal = some(url),
+      ret url
   )
-
-  ir.newModule(normalizeIRName "URL.parse")
-  vm.registerBuiltin(
-    "BALI_URLPARSE",
-    proc(op: Operation) =
-      if vm.registers.callArgs.len < 1:
-        vm.registers.retVal = some null()
-        return
-
+  
+  # URL.parse()
+  runtime.defineFn(
+    "URL.parse",
+    proc =
       var osource: Option[MAtom]
 
       if (;
-        osource = vm.argument(
+        osource = runtime.argument(
           1, true, "URL.new: At least 1 argument required, but only {nargs} passed"
         )
         !osource
@@ -109,8 +105,7 @@ proc generateStdIR*(vm: PulsarInterpreter, ir: IRGenerator) =
       let source = &move(osource)
 
       if source.kind != String:
-        vm.registers.retVal = some null()
-        return
+        ret null()
 
       var parsed =
         try:
@@ -125,6 +120,5 @@ proc generateStdIR*(vm: PulsarInterpreter, ir: IRGenerator) =
       var url = obj()
       transposeUrlToObject(parsed, url, source)
 
-      vm.registers.retVal = some(url),
+      ret url
   )
-  ir.call("BALI_URLPARSE")

--- a/src/bali/stdlib/uri.nim
+++ b/src/bali/stdlib/uri.nim
@@ -47,7 +47,7 @@ proc generateStdIR*(runtime: Runtime) =
   # URL constructor (`new URL()` syntax)
   runtime.defineConstructor(
     "URL",
-    proc =
+    proc() =
       var osource: Option[MAtom]
 
       if (;
@@ -86,12 +86,13 @@ proc generateStdIR*(runtime: Runtime) =
       transposeUrlToObject(parsed, url, source)
 
       ret url
+    ,
   )
-  
+
   # URL.parse()
   runtime.defineFn(
     "URL.parse",
-    proc =
+    proc() =
       var osource: Option[MAtom]
 
       if (;
@@ -121,4 +122,5 @@ proc generateStdIR*(runtime: Runtime) =
       transposeUrlToObject(parsed, url, source)
 
       ret url
+    ,
   )

--- a/tests/data/math-hypot.js
+++ b/tests/data/math-hypot.js
@@ -1,0 +1,2 @@
+let x = Math.hypot(3)
+console.log(x)

--- a/tests/data/return-outside-fn.js
+++ b/tests/data/return-outside-fn.js
@@ -1,0 +1,2 @@
+// This should throw a SyntaxError.
+return 1337

--- a/tests/data/url-json-serialize.js
+++ b/tests/data/url-json-serialize.js
@@ -1,1 +1,5 @@
-let url = new URL("")
+let url = new URL("https://github.com")
+console.log("URL:", url)
+
+let serialized = JSON.stringify(url)
+console.log("Serialized:", serialized)

--- a/tests/runtime/interop.nim
+++ b/tests/runtime/interop.nim
@@ -1,0 +1,23 @@
+import bali/grammar/prelude
+import bali/runtime/prelude
+import bali/internal/sugar
+
+proc main {.inline.} =
+  let parser = newParser("""
+let greeting = greet("tray")
+console.log(greeting)
+""")
+  let ast = parser.parse()
+  let runtime = newRuntime("interop.js", ast)
+
+  runtime.defineFn(
+    "greet",
+    proc =
+      let arg = runtime.ToString(&runtime.argument(1))
+      ret str("Hi there, " & arg)
+  )
+
+  runtime.run()
+
+when isMainModule:
+  main()


### PR DESCRIPTION
- **(fix) grammar/parser: forbid `return` outside of a function**
- **(fix) grammar/parser: fix grammatical error in error message**
- **(add) runtime: add interop helpers**
- **(fix) stdlib/math: use new interop interfaces**
- **(add) stdlib/[console, uri]: move to new interop interface**
- **(add) stdlib/[json, base64]: move to new interop interface**
- **(xxx) fmt: format code**
- **(xxx) update README.md**

Fixes #29
