### PR TITLE
Add support for JS types

### DIFF
--- a/src/bali/runtime/atom_helpers.nim
+++ b/src/bali/runtime/atom_helpers.nim
@@ -12,5 +12,21 @@ func isObject*(atom: MAtom): bool {.inline.} =
 func isNull*(atom: MAtom): bool {.inline.} =
   atom.kind == Null
 
+proc `[]`*(atom: MAtom, name: string): MAtom {.inline.} =
+  if atom.kind != Object:
+    raise newException(ValueError, $atom.kind & " does not have field access methods")
+  
+  atom.objValues[atom.objFields[name]]
+
+proc `[]=`*(atom: var MAtom, name: string, value: sink MAtom) {.inline.} =
+  if atom.kind != Object:
+    raise newException(ValueError, $atom.kind & " does not have field access methods")
+
+  if not atom.objFields.contains(name):
+    atom.objValues &= move(value)
+    atom.objFields[name] = atom.objValues.len
+  else:
+    atom.objValues[atom.objFields[name]] = move(value)
+
 func undefined*(): MAtom {.inline.} =
   obj()

--- a/src/bali/runtime/interpreter.nim
+++ b/src/bali/runtime/interpreter.nim
@@ -737,6 +737,14 @@ proc generateIRForScope*(runtime: Runtime, scope: Scope) =
 
   if name != "outer":
     runtime.loadArgumentsOntoStack(fn)
+  else:
+    constants.generateStdIr(runtime)
+
+    for typ in runtime.types:
+      let idx = runtime.addrIdx
+      runtime.markGlobal(typ.name)
+      runtime.ir.loadObject(idx)
+      runtime.ir.markGlobal(idx)
 
   for stmt in scope.stmts:
     runtime.generateIR(fn, stmt)
@@ -769,7 +777,7 @@ proc generateInternalIR*(runtime: Runtime) =
           "\"; returning undefined."
         runtime.vm.addAtom(obj(), storeAt)
         return
-
+      
       let value = atom.objValues[atom.objFields[&ident.getStr()]]
       runtime.vm.addAtom(value, storeAt),
   )
@@ -783,7 +791,6 @@ proc run*(runtime: Runtime) =
   base64.generateStdIR(runtime)
   json.generateStdIR(runtime)
   parseIntGenerateStdIR(runtime.vm, runtime.ir)
-  constants.generateStdIR(runtime)
 
   runtime.generateInternalIR()
 
@@ -791,6 +798,8 @@ proc run*(runtime: Runtime) =
     test262.generateStdIR(runtime.vm, runtime.ir)
 
   runtime.generateIRForScope(runtime.ast.scopes[0])
+
+  constants.generateStdIR(runtime)
 
   let source = runtime.ir.emit()
 

--- a/src/bali/runtime/interpreter.nim
+++ b/src/bali/runtime/interpreter.nim
@@ -341,7 +341,7 @@ proc generateIR*(
         of cakIdent:
           info "interpreter: passing ident parameter to function with ident: " &
             arg.ident
-
+          
           runtime.ir.passArgument(runtime.index(arg.ident, defaultParams(fn)))
         of cakAtom: # already loaded via the statement expander
           let ident = $i

--- a/src/bali/runtime/types.nim
+++ b/src/bali/runtime/types.nim
@@ -162,7 +162,7 @@ proc createAtom*(typ: JSType): MAtom =
 
 proc createObjFromType*[T](runtime: Runtime, typ: typedesc[T]): MAtom =
   for etyp in runtime.types:
-    if etyp.proto == hash(typ()):
+    if etyp.proto == hash($typ):
       return etyp.createAtom()
 
   raise newException(ValueError, "No such registered type: `" & $typ & '`')
@@ -172,7 +172,7 @@ proc defineFn*[T](runtime: Runtime, prototype: typedesc[T], name: string, fn: Na
   
   let typName = (proc: Option[string] =
     for typ in runtime.types:
-      if typ.proto == hash(prototype()):
+      if typ.proto == hash($prototype):
         return typ.name.some()
 
     none(string)
@@ -196,7 +196,7 @@ proc registerType*[T](runtime: Runtime, name: string, prototype: typedesc[T]) =
   for fname, fatom in prototype().fieldPairs:
     jsType.members[fname] = initAtomOrFunction[NativeFunction](undefined())
 
-  jsType.proto = hash(prototype())
+  jsType.proto = hash($prototype)
   jsType.name = name
 
   runtime.types &= jsType.move()

--- a/src/bali/runtime/types.nim
+++ b/src/bali/runtime/types.nim
@@ -6,6 +6,7 @@ import mirage/runtime/prelude
 import bali/grammar/prelude
 import bali/internal/sugar
 import bali/runtime/[normalize, atom_obj_variant, atom_helpers]
+import pretty
 
 type
   NativeFunction* = proc()
@@ -123,7 +124,7 @@ proc markGlobal*(runtime: Runtime, ident: string) =
 proc markLocal*(runtime: Runtime, fn: Function, ident: string) =
   var toRm: seq[int]
   for i, value in runtime.values:
-    if value.kind == vkLocal and value.ownerFunc == hash(fn):
+    if value.kind == vkLocal and value.ownerFunc == hash(fn) and value.identifier == ident:
       toRm &= i
 
   for rm in toRm:
@@ -205,7 +206,7 @@ proc registerType*[T](runtime: Runtime, name: string, prototype: typedesc[T]) =
     "BALI_CONSTRUCTOR_" & name.toUpperAscii(),
     proc(_: Operation) =
       if runtime.types[typIdx].constructor == nil:
-        raise newException(Defect, "BUG: Constructor for type `" & name & "` was not defined prior to execution!")
+        runtime.vm.typeError(runtime.types[typIdx].name & " is not a constructor")
 
       runtime.types[typIdx].constructor()
   )

--- a/src/bali/runtime/types.nim
+++ b/src/bali/runtime/types.nim
@@ -1,10 +1,11 @@
 ## Runtime types
 
-import std/[options, hashes, logging, strutils]
+import std/[options, hashes, logging, strutils, tables]
 import mirage/ir/generator
 import mirage/runtime/prelude
 import bali/grammar/prelude
-import bali/runtime/[normalize]
+import bali/internal/sugar
+import bali/runtime/[normalize, atom_obj_variant, atom_helpers]
 
 type
   NativeFunction* = proc()
@@ -47,6 +48,13 @@ type
   InterpreterOpts* = object
     test262*: bool = false
 
+  JSType* = object
+    name*: string
+    constructor*: NativeFunction
+    members*: Table[string, AtomOrFunction[NativeFunction]]
+
+    proto*: Hash
+
   Runtime* = ref object
     ast*: AST
     ir*: IRGenerator
@@ -57,6 +65,8 @@ type
     values*: seq[Value]
     semanticErrors*: seq[SemanticError]
     clauses*: seq[string]
+
+    types*: seq[JSType]
 
 proc unknownIdentifier*(identifier: string): SemanticError {.inline.} =
   SemanticError(kind: UnknownIdentifier, unknown: identifier)
@@ -138,14 +148,81 @@ proc defineFn*(runtime: Runtime, name: string, fn: NativeFunction) =
   )
   runtime.ir.call(builtinName)
 
+proc createAtom*(typ: JSType): MAtom =
+  var atom = obj()
+  
+  for name, member in typ.members:
+    if member.isAtom():
+      let idx = atom.objValues.len
+      atom.objValues &= undefined()
+      atom.objFields[name] = idx
+
+  atom
+
+proc createObjFromType*[T](runtime: Runtime, typ: typedesc[T]): MAtom =
+  for etyp in runtime.types:
+    if etyp.proto == hash(typ()):
+      return etyp.createAtom()
+
+  raise newException(ValueError, "No such registered type: `" & $typ & '`')
+
+proc defineFn*[T](runtime: Runtime, prototype: typedesc[T], name: string, fn: NativeFunction) =
+  ## Expose a method to the JavaScript runtime for a particular type.
+  
+  let typName = (proc: Option[string] =
+    for typ in runtime.types:
+      if typ.proto == hash(prototype()):
+        return typ.name.some()
+
+    none(string)
+  )()
+
+  if not *typName:
+    raise newException(ValueError, "Attempt to define function `" & name & "` for undefined prototype")
+    
+  let moduleName = normalizeIRName(&typName & '.' & name)
+  runtime.ir.newModule(moduleName)
+  let name = "BALI_" & toUpperAscii((&typName).normalizeIRName()) & '_' & toUpperAscii(normalizeIRName name)
+  runtime.vm.registerBuiltin(name,
+    proc(_: Operation) =
+      fn()
+  )
+  runtime.ir.call(name)
+
+proc registerType*[T](runtime: Runtime, name: string, prototype: typedesc[T]) =
+  var jsType: JSType
+  
+  for fname, fatom in prototype().fieldPairs:
+    jsType.members[fname] = initAtomOrFunction[NativeFunction](undefined())
+
+  jsType.proto = hash(prototype())
+  jsType.name = name
+
+  runtime.types &= jsType.move()
+  let typIdx = runtime.types.len - 1
+  
+  runtime.vm.registerBuiltin(
+    "BALI_CONSTRUCTOR_" & name.toUpperAscii(),
+    proc(_: Operation) =
+      if runtime.types[typIdx].constructor == nil:
+        raise newException(Defect, "BUG: Constructor for type `" & name & "` was not defined prior to execution!")
+
+      runtime.types[typIdx].constructor()
+  )
+
 proc defineConstructor*(runtime: Runtime, name: string, fn: NativeFunction) {.inline.} =
   debug "runtime: exposing constructor for type: " & name
   ## Expose a constructor for a type to a JavaScript runtime.
-  runtime.vm.registerBuiltin(
-    "BALI_CONSTRUCTOR_" & name,
-    proc(_: Operation) =
-      fn(),
-  )
+  
+  var found = false
+  for i, jtype in runtime.types:
+    if jtype.name == name:
+      found = true
+      runtime.types[i].constructor = fn
+      break
+  
+  if not found:
+    raise newException(ValueError, "Attempt to define constructor for unknown type: " & name)
 
 template ret*(atom: MAtom) =
   ## Shorthand for:

--- a/src/bali/stdlib/json.nim
+++ b/src/bali/stdlib/json.nim
@@ -42,6 +42,9 @@ proc convertJsonNodeToAtom*(node: JsonNode): MAtom =
 
   null()
 
+type
+  JSON = object
+
 proc atomToJsonNode*(atom: MAtom): JsonNode =
   if atom.kind == Integer:
     return newJInt(&atom.getInt())
@@ -71,10 +74,13 @@ proc atomToJsonNode*(atom: MAtom): JsonNode =
 proc generateStdIR*(runtime: Runtime) =
   info "json: generating IR interfaces"
 
+  runtime.registerType("JSON", JSON)
+
   ## 25.5.1 JSON.parse ( text [ , reviver ] )
   ## This function parses a JSON text (a JSON-formatted String) and produces an ECMAScript language value. The JSON format represents literals, arrays, and objects with a syntax similar to the syntax for ECMAScript literals, Array Initializers, and Object Initializers. After parsing, JSON objects are realized as ECMAScript objects. JSON arrays are realized as ECMAScript Array instances. JSON strings, numbers, booleans, and null are realized as ECMAScript Strings, Numbers, Booleans, and null.
   runtime.defineFn(
-    "JSON.parse",
+    JSON,
+    "parse",
     proc() =
       # 1. Let jsonString be ? ToString(text).
       let jsonString =
@@ -99,7 +105,8 @@ proc generateStdIR*(runtime: Runtime) =
   # FIXME: not compliant yet!
   ## This function returns a String in UTF-16 encoded JSON format representing an ECMAScript language value, or undefined. It can take three parameters. The value parameter is an ECMAScript language value, which is usually an object or array, although it can also be a String, Boolean, Number or null. The optional replacer parameter is either a function that alters the way objects and arrays are stringified, or an array of Strings and Numbers that acts as an inclusion list for selecting the object properties that will be stringified. The optional space parameter is a String or Number that allows the result to have white space injected into it to improve human readability.
   runtime.defineFn(
-    "JSON.stringify",
+    JSON,
+    "stringify",
     proc() =
       let
         atom = &runtime.argument(1)

--- a/src/bali/stdlib/math.nim
+++ b/src/bali/stdlib/math.nim
@@ -53,7 +53,8 @@ proc generateStdIr*(runtime: Runtime) =
 
   # Math.pow
   runtime.defineFn(
-    "Math.pow",
+    JSMath,
+    "pow",
     proc() =
       let
         value = runtime.ToNumber(&runtime.argument(1))
@@ -65,7 +66,8 @@ proc generateStdIr*(runtime: Runtime) =
 
   # Math.cos
   runtime.defineFn(
-    "Math.cos",
+    JSMath,
+    "cos",
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
       ret floating cos(value)
@@ -74,7 +76,8 @@ proc generateStdIr*(runtime: Runtime) =
 
   # Math.sqrt
   runtime.defineFn(
-    "Math.sqrt",
+    JSMath,
+    "sqrt",
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
       ret floating sqrt(value)
@@ -83,7 +86,8 @@ proc generateStdIr*(runtime: Runtime) =
 
   # Math.tanh
   runtime.defineFn(
-    "Math.tanh",
+    JSMath,
+    "tanh",
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
@@ -93,7 +97,8 @@ proc generateStdIr*(runtime: Runtime) =
 
   # Math.sin
   runtime.defineFn(
-    "Math.sin",
+    JSMath,
+    "sin",
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
@@ -103,7 +108,8 @@ proc generateStdIr*(runtime: Runtime) =
 
   # Math.sinh
   runtime.defineFn(
-    "Math.sinh",
+    JSMath,
+    "sinh",
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
@@ -113,7 +119,8 @@ proc generateStdIr*(runtime: Runtime) =
 
   # Math.tan
   runtime.defineFn(
-    "Math.tan",
+    JSMath,
+    "tan",
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
@@ -123,7 +130,8 @@ proc generateStdIr*(runtime: Runtime) =
 
   # Math.trunc
   runtime.defineFn(
-    "Math.trunc",
+    JSMath,
+    "trunc",
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
@@ -133,7 +141,8 @@ proc generateStdIr*(runtime: Runtime) =
 
   # Math.floor
   runtime.defineFn(
-    "Math.floor",
+    JSMath,
+    "floor",
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
@@ -143,7 +152,8 @@ proc generateStdIr*(runtime: Runtime) =
 
   # Math.ceil
   runtime.defineFn(
-    "Math.ceil",
+    JSMath,
+    "ceil",
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
@@ -153,7 +163,8 @@ proc generateStdIr*(runtime: Runtime) =
 
   # Math.cbrt
   runtime.defineFn(
-    "Math.cbrt",
+    JSMath,
+    "cbrt",
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
@@ -163,7 +174,8 @@ proc generateStdIr*(runtime: Runtime) =
 
   # Math.log
   runtime.defineFn(
-    "Math.log",
+    JSMath,
+    "log",
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
@@ -173,7 +185,8 @@ proc generateStdIr*(runtime: Runtime) =
 
   # Math.abs
   runtime.defineFn(
-    "Math.abs",
+    JSMath,
+    "abs",
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
@@ -183,7 +196,8 @@ proc generateStdIr*(runtime: Runtime) =
 
   # Math.max
   runtime.defineFn(
-    "Math.max",
+    JSMath,
+    "max",
     proc() =
       let
         a = runtime.ToNumber(&runtime.argument(1))
@@ -195,7 +209,8 @@ proc generateStdIr*(runtime: Runtime) =
 
   # Math.min
   runtime.defineFn(
-    "Math.min",
+    JSMath,
+    "min",
     proc() =
       let
         a = runtime.ToNumber(&runtime.argument(1))

--- a/src/bali/stdlib/math.nim
+++ b/src/bali/stdlib/math.nim
@@ -35,9 +35,6 @@ proc generateStdIr*(runtime: Runtime) =
   info "math: generating IR interfaces"
 
   runtime.registerType("Math", JSMath)
-  runtime.defineConstructor("Math", proc =
-    runtime.vm.typeError("Math is not a constructor")
-  )
 
   # Math.random
   # WARN: Do not use this for cryptography! This uses one of eight highly predictable pseudo-random

--- a/src/bali/stdlib/uri.nim
+++ b/src/bali/stdlib/uri.nim
@@ -1,7 +1,7 @@
 ## JavaScript URL API - uses sanchar's builtin URL parser
 import std/[options, logging, tables]
 import bali/internal/sugar
-import bali/runtime/[objects, normalize, arguments, types]
+import bali/runtime/[objects, normalize, arguments, types, atom_helpers]
 import bali/runtime/abstract/coercion
 import bali/stdlib/errors
 import mirage/ir/generator
@@ -12,37 +12,37 @@ import pretty
 
 var parser = newURLParser()
 
-proc transposeUrlToObject(parsed: URL, url: var MAtom, source: MAtom) =
-  when not defined(danger):
-    assert url.kind == Object,
-      "transposeUrlToObject() was given non-Object type: " & $url.kind
+type
+  JSURL = object
+    host*: string
+    hostname*: string
+    pathname*: string
+    port*: int
+    protocol*: string
+    search*: string
+    href*: string
+    origin*: string
+    source*: string
+    hash*: string
 
-  url.objFields["hostname"] = 0 #str parsed.hostname()
-  url.objFields["pathname"] = 1 #str parsed.path()
-  url.objFields["port"] = 2 #integer parsed.port()
-  url.objFields["protocol"] = 3 #str parsed.scheme()
-  url.objFields["search"] = 4 #str parsed.query()
-  url.objFields["host"] = 5 #str parsed.hostname()
-  url.objFields["href"] = 6 #source
-  url.objFields["origin"] = 7
-  url.objFields["hash"] = 8
+proc transposeUrlToObject(runtime: Runtime, parsed: URL, source: string): MAtom =
+  var url = runtime.createObjFromType(JSURL)
+  url["hostname"] = str(parsed.hostname())
+  url["pathname"] = parsed.path().str()
+  url["port"] = parsed.port().int.integer()
+  url["protocol"] = str(parsed.scheme() & ':')
+  url["search"] = parsed.query().str()
+  url["hostname"] = parsed.hostname().str()
+  url["source"] = source.str()
+  url["origin"] = str(parsed.scheme() & "://" & parsed.hostname() & ":" & $parsed.port())
+  url["hash"] = (if parsed.fragment().len > 0: str '#' & parsed.fragment() else: str newString(0))
 
-  url.objValues =
-    @[
-      str parsed.hostname(),
-      str parsed.path(),
-      integer parsed.port().int,
-      str parsed.scheme(),
-      str parsed.query(),
-      str parsed.hostname(),
-      source,
-      str(parsed.scheme() & "://" & parsed.hostname() & ":" & $parsed.port()),
-      (if parsed.fragment().len > 0: str '#' & parsed.fragment()
-      else: str newString(0)),
-    ]
+  url
 
 proc generateStdIR*(runtime: Runtime) =
   info "url: generating IR interfaces"
+
+  runtime.registerType("URL", JSURL)
 
   # URL constructor (`new URL()` syntax)
   runtime.defineConstructor(
@@ -81,11 +81,7 @@ proc generateStdIR*(runtime: Runtime) =
       if parsed.scheme().len < 1:
         return
 
-      var url = obj()
-
-      transposeUrlToObject(parsed, url, source)
-
-      ret url
+      ret transposeUrlToObject(runtime, parsed, &source.getStr())
     ,
   )
 
@@ -117,10 +113,6 @@ proc generateStdIR*(runtime: Runtime) =
           debug "url: this is the function variant, so no error will be thrown."
           URL()
 
-      # allocate object
-      var url = obj()
-      transposeUrlToObject(parsed, url, source)
-
-      ret url
+      ret transposeUrlToObject(runtime, parsed, &source.getStr())
     ,
   )

--- a/src/bali/stdlib/uri.nim
+++ b/src/bali/stdlib/uri.nim
@@ -87,7 +87,8 @@ proc generateStdIR*(runtime: Runtime) =
 
   # URL.parse()
   runtime.defineFn(
-    "URL.parse",
+    JSURL,
+    "parse",
     proc() =
       var osource: Option[MAtom]
 

--- a/tests/data/proto-001.js
+++ b/tests/data/proto-001.js
@@ -1,0 +1,2 @@
+let y = Math.random()
+console.log(y)

--- a/tests/runtime/prototypes_001.nim
+++ b/tests/runtime/prototypes_001.nim
@@ -6,7 +6,6 @@ import mirage/atom
 import pretty
 
 let parser = newParser("""
-console.log(EpicClas)
 EpicClass.die()
 """) # I've grown tired of manually writing the AST :(
 
@@ -14,7 +13,7 @@ let program = parser.parse()
 
 type
   EpicClass* = object
-    myName*: string
+    myName*: string = "Deine Mutter"
 
 var runtime = newRuntime("t001.js", program)
 runtime.registerType(
@@ -25,7 +24,6 @@ runtime.defineFn(
   EpicClass,
   "die",
   proc =
-    echo "Oooops! You killed the engine by invoking that!"
-    quit(0)
+    quit "Oooops! You killed the engine by invoking that!"
 )
 runtime.run()


### PR DESCRIPTION
- **(feat) runtime+emitter: initial prototype implementation**
- **(fix) stdlib/math: switch over to using `Math` type**
- **(fix) stdlib/url: move to using `JSURL` type**
- **(fix) emitter: don't pop random values in same scope out for no reason**
- **(fix) stdlib/json: move to `JSON` type**
- **(fix) stdlib/math: remove stub constructor for `JSMath`**
- **(fix) runtime: fix how types are distinguished**

This PR adds support for proper types in Nim that are then interfaced with the JavaScript runtime.
