### PR TITLE
Add support for nested field access

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ runtime.run()
 - Get arithmetic operations working    [X]
 - Console API                          [X]
 - While loops                          [X]
+- Nested object field access           [X]
 - For loops                            [ ]
 - Modules                              [ ]
 - Async                                [ ]

--- a/src/bali/grammar/parser.nim
+++ b/src/bali/grammar/parser.nim
@@ -469,10 +469,8 @@ proc parseArguments*(parser: Parser): Option[PositionedArguments] =
           let splitted = token.ident.split('.')
           if splitted.len < 2:
             parser.error Other, "expected name after . operator"
-          elif splitted.len > 2:
-            parser.error Other, "nested field access is not supported yet. Sorry!"
 
-          args.pushFieldAccess(splitted[0], splitted[1])
+          args.pushFieldAccess(createFieldAccess(splitted))
         else:
           args.pushIdent(token.ident)
     of TokenKind.Number, TokenKind.String:

--- a/src/bali/grammar/statement.nim
+++ b/src/bali/grammar/statement.nim
@@ -24,7 +24,7 @@ type
     WhileStmt
     Increment
     Decrement
-  
+
   FieldAccess* = ref object
     prev*, next*: FieldAccess
     identifier*: string
@@ -174,7 +174,7 @@ proc pushIdent*(args: var PositionedArguments, ident: string) {.inline.} =
 func createFieldAccess*(splitted: seq[string]): FieldAccess =
   ## From a sequence of identifiers (assuming they are in sorted order of accesses),
   ## create a `FieldAccess`, which has a "view" of the top of the field access chain.
-  var 
+  var
     top = FieldAccess(identifier: splitted[0])
     curr = top
 
@@ -187,9 +187,7 @@ func createFieldAccess*(splitted: seq[string]): FieldAccess =
 
   top
 
-proc pushFieldAccess*(
-  args: var PositionedArguments, access: FieldAccess
-) {.inline.} =
+proc pushFieldAccess*(args: var PositionedArguments, access: FieldAccess) {.inline.} =
   args &= CallArg(kind: cakFieldAccess, access: access)
 
 proc pushAtom*(args: var PositionedArguments, atom: MAtom) {.inline.} =

--- a/src/bali/grammar/tokenizer.nim
+++ b/src/bali/grammar/tokenizer.nim
@@ -352,7 +352,7 @@ proc consumeString*(tokenizer: Tokenizer): Token =
     str &= c
     tokenizer.advance()
 
-  if not malformed and not str.endsWith(closesWith):
+  if not malformed and (not tokenizer.eof and &tokenizer.charAt() != closesWith):
     debug "tokenizer: string does not end with expected closing character"
     malformed = true
     malformationReason = MalformedStringReason.UnclosedString

--- a/src/bali/runtime/atom_helpers.nim
+++ b/src/bali/runtime/atom_helpers.nim
@@ -28,5 +28,31 @@ proc `[]=`*(atom: var MAtom, name: string, value: sink MAtom) {.inline.} =
   else:
     atom.objValues[atom.objFields[name]] = move(value)
 
+{.push inline.}
+func wrap*(val: int | uint | string | float): MAtom =
+  when val is int:
+    return integer(val)
+
+  when val is uint:
+    return uinteger(val)
+
+  when val is string:
+    return str(val)
+
+  when val is float:
+    return floating(val)
+
+func wrap*[T: not MAtom](val: openArray[T]): MAtom =
+  var vec = sequence(newSeq[MAtom](0))
+
+  for v in val:
+    vec.sequence &= v.wrap()
+
+  vec
+
+func wrap*(val: seq[MAtom]): MAtom =
+  sequence(val)
+{.pop.}
+
 func undefined*(): MAtom {.inline.} =
   obj()

--- a/src/bali/runtime/atom_helpers.nim
+++ b/src/bali/runtime/atom_helpers.nim
@@ -1,6 +1,7 @@
 ## Atom functions
 
 import std/tables
+import bali/grammar/statement
 import mirage/atom
 
 func isUndefined*(atom: MAtom): bool {.inline.} =
@@ -24,7 +25,7 @@ proc `[]=`*(atom: var MAtom, name: string, value: sink MAtom) {.inline.} =
 
   if not atom.objFields.contains(name):
     atom.objValues &= move(value)
-    atom.objFields[name] = atom.objValues.len
+    atom.objFields[name] = atom.objValues.len - 1
   else:
     atom.objValues[atom.objFields[name]] = move(value)
 
@@ -49,6 +50,14 @@ func wrap*[T: not MAtom](val: openArray[T]): MAtom =
     vec.sequence &= v.wrap()
 
   vec
+
+func wrap*[T: object](obj: T): MAtom =
+  var mObj = atom.obj()
+
+  for name, field in obj.fieldPairs:
+    mObj[name] = field.wrap()
+
+  mObj
 
 func wrap*(val: seq[MAtom]): MAtom =
   sequence(val)

--- a/src/bali/runtime/interpreter.nim
+++ b/src/bali/runtime/interpreter.nim
@@ -6,7 +6,7 @@ import mirage/ir/generator
 import mirage/runtime/[tokenizer, prelude]
 import bali/grammar/prelude
 import bali/internal/sugar
-import bali/runtime/[normalize, types, atom_helpers, atom_obj_variant]
+import bali/runtime/[normalize, types, atom_helpers, atom_obj_variant, arguments]
 import bali/stdlib/prelude
 import crunchy, pretty
 
@@ -202,28 +202,39 @@ proc semanticError*(runtime: Runtime, error: SemanticError) =
 
   runtime.semanticErrors &= error
 
+proc loadFieldAccessStrings*(runtime: Runtime, access: FieldAccess) =
+  var curr = access.next
+  assert(curr != nil, "Field access on single ident (or top of access chain was not provided)")
+
+  while curr != nil:
+    runtime.ir.loadStr(runtime.addrIdx, curr.identifier)
+    runtime.ir.passArgument(runtime.addrIdx)
+    inc runtime.addrIdx
+
+    curr = curr.next
+
 proc resolveFieldAccess*(
-    runtime: Runtime, fn: Function, stmt: Statement, address: int, field: string
+  runtime: Runtime, fn: Function, stmt: Statement, address: uint, access: FieldAccess
 ): uint =
-  let internalName = $(hash(stmt) !& hash(ident) !& hash(field))
+  let internalName = $(hash(stmt) !& hash(ident) !& hash(access.identifier))
   runtime.generateIR(
     fn, createImmutVal(internalName, null()), internal = true, ownerStmt = some(stmt)
   )
-  let accessResult = runtime.addrIdx - 1
+  let accessResult = runtime.addrIdx - 1 # index where the value will be stored
 
-  # start preparing for call to internal field resolver
+  # Pass the index at which the atom is located
+  inc runtime.addrIdx
+  runtime.ir.loadUint(runtime.addrIdx, address)
+  runtime.ir.passArgument(runtime.addrIdx)
+  
+  # Pass the index at wbich the result is to be stored
   inc runtime.addrIdx
   runtime.ir.loadUint(runtime.addrIdx, accessResult)
-  inc runtime.addrIdx
-  runtime.ir.loadInt(runtime.addrIdx, address)
-  inc runtime.addrIdx
-  runtime.ir.loadStr(runtime.addrIdx, field)
-  inc runtime.addrIdx
+  runtime.ir.passArgument(runtime.addrIdx)
 
-  runtime.ir.passArgument(runtime.addrIdx - 3) # pass `accessResult`
-  runtime.ir.passArgument(runtime.addrIdx - 2) # pass `address`
-  runtime.ir.passArgument(runtime.addrIdx - 1) # pass `field`
-
+  # Pass all the fields
+  runtime.loadFieldAccessStrings(access)
+  
   runtime.ir.call("BALI_RESOLVEFIELD")
   runtime.ir.resetArgs()
 
@@ -349,7 +360,7 @@ proc generateIR*(
           runtime.ir.passArgument(runtime.index(ident, internalIndex(stmt)))
         of cakFieldAccess:
           let index = runtime.resolveFieldAccess(
-            fn, stmt, int runtime.index(arg.fIdent, defaultParams(fn)), arg.fField
+            fn, stmt, runtime.index(arg.access.identifier, defaultParams(fn)), arg.access
           )
           runtime.ir.markGlobal(index)
           runtime.ir.passArgument(index)
@@ -393,7 +404,7 @@ proc generateIR*(
         runtime.ir.passArgument(runtime.index(ident, internalIndex(stmt)))
       of cakFieldAccess:
         let index = runtime.resolveFieldAccess(
-          fn, stmt, int runtime.index(arg.fIdent, defaultParams(fn)), arg.fField
+          fn, stmt, runtime.index(arg.access.identifier, defaultParams(fn)), arg.access
         )
         runtime.ir.markGlobal(index)
         runtime.ir.passArgument(index)
@@ -754,15 +765,35 @@ proc generateIRForScope*(runtime: Runtime, scope: Scope) =
     curr = &curr.next
     runtime.generateIRForScope(curr)
 
+proc findField*(atom: MAtom, accesses: FieldAccess): MAtom =
+  if accesses.identifier in atom.objFields:
+    if accesses.next == nil:
+      return atom.objValues[atom.objFields[accesses.identifier]]
+    else:
+      return atom.findField(accesses.next)
+  else:
+    return undefined()
+
 proc generateInternalIR*(runtime: Runtime) =
   runtime.ir.newModule("BALI_RESOLVEFIELD")
   runtime.vm.registerBuiltin(
     "BALI_RESOLVEFIELD_INTERNAL",
     proc(op: Operation) =
       let
-        ident = runtime.vm.registers.callArgs.pop()
-        index = uint(&getInt(runtime.vm.registers.callArgs.pop()))
-        storeAt = uint(&getInt(runtime.vm.registers.callArgs.pop()))
+        index = uint(&(&runtime.argument(1)).getInt())
+        storeAt = uint(&(&runtime.argument(2)).getInt())
+        accesses = createFieldAccess(
+          (proc: seq[string] =
+            if runtime.argumentCount() < 3:
+              return
+            
+            var accesses: seq[string]
+            for i in 3 .. runtime.argumentCount():
+              accesses.add(&(&runtime.argument(i)).getStr())
+
+            accesses
+          )()
+        )
 
       let atom = runtime.vm.stack[index]
         # FIXME: weird bug with mirage, `get` returns a NULL atom.
@@ -776,27 +807,19 @@ proc generateInternalIR*(runtime: Runtime) =
         if typ.singletonId == index:
           debug "runtime: singleton ID for type `" & typ.name &
             "` matches field access index"
-          for field, member in typ.members:
-            if field == &ident.getStr():
-              debug "runtime: found field in singleton `" & typ.name & "`: " & field
-              if member.isFn:
-                error "runtime: FIXME: field access into functions is not supported yet!"
-                runtime.vm.typeError(
-                  "FIXME: Field access into functions is not supported yet!"
-                )
-                return
-              else:
-                runtime.vm.addAtom(member.atom(), storeAt)
-                return
+          
+          for name, member in typ.members:
+            if member.isFn: continue
+            if name != accesses.identifier: continue
 
-      if not atom.objFields.contains(&ident.getStr()):
-        debug "runtime: atom does not have any field \"" & &ident.getStr() &
-          "\"; returning undefined."
-        runtime.vm.addAtom(obj(), storeAt)
-        return
+            if accesses.next != nil:
+              assert(member.atom().kind == Object)
+              runtime.vm.addAtom(member.atom().findField(accesses.next), storeAt)
+            else:
+              runtime.vm.addAtom(member.atom(), storeAt)
+            return
 
-      let value = atom.objValues[atom.objFields[&ident.getStr()]]
-      runtime.vm.addAtom(value, storeAt),
+      runtime.vm.addAtom(atom.findField(accesses), storeAt),
   )
   runtime.ir.call("BALI_RESOLVEFIELD_INTERNAL")
 

--- a/src/bali/runtime/types.nim
+++ b/src/bali/runtime/types.nim
@@ -205,7 +205,9 @@ proc registerType*[T](runtime: Runtime, name: string, prototype: typedesc[T]) =
   var jsType: JSType
 
   for fname, fatom in prototype().fieldPairs:
-    jsType.members[fname] = initAtomOrFunction[NativeFunction](undefined())
+    jsType.members[fname] = initAtomOrFunction[NativeFunction](
+      fname.wrap()
+    )
 
   jsType.proto = hash($prototype)
   jsType.name = name

--- a/src/bali/runtime/types.nim
+++ b/src/bali/runtime/types.nim
@@ -205,9 +205,7 @@ proc registerType*[T](runtime: Runtime, name: string, prototype: typedesc[T]) =
   var jsType: JSType
 
   for fname, fatom in prototype().fieldPairs:
-    jsType.members[fname] = initAtomOrFunction[NativeFunction](
-      fatom.wrap()
-    )
+    jsType.members[fname] = initAtomOrFunction[NativeFunction](fatom.wrap())
 
   jsType.proto = hash($prototype)
   jsType.name = name

--- a/src/bali/runtime/types.nim
+++ b/src/bali/runtime/types.nim
@@ -206,7 +206,7 @@ proc registerType*[T](runtime: Runtime, name: string, prototype: typedesc[T]) =
 
   for fname, fatom in prototype().fieldPairs:
     jsType.members[fname] = initAtomOrFunction[NativeFunction](
-      fname.wrap()
+      fatom.wrap()
     )
 
   jsType.proto = hash($prototype)

--- a/tests/runtime/field_accesses_001.nim
+++ b/tests/runtime/field_accesses_001.nim
@@ -1,0 +1,8 @@
+import bali/grammar/statement
+import pretty
+
+print createFieldAccess(@[
+  "myUrl",
+  "hostname",
+  "length"
+]) # `myUrl.hostname.length`

--- a/tests/runtime/field_accesses_001.nim
+++ b/tests/runtime/field_accesses_001.nim
@@ -1,8 +1,4 @@
 import bali/grammar/statement
 import pretty
 
-print createFieldAccess(@[
-  "myUrl",
-  "hostname",
-  "length"
-]) # `myUrl.hostname.length`
+print createFieldAccess(@["myUrl", "hostname", "length"]) # `myUrl.hostname.length`

--- a/tests/runtime/type_nested_object.nim
+++ b/tests/runtime/type_nested_object.nim
@@ -1,0 +1,38 @@
+import std/[options, tables, logging]
+import bali/grammar/prelude
+import bali/runtime/prelude
+import bali/runtime/abstract/coercion
+import mirage/atom
+import pretty, colored_logger
+
+let parser = newParser(
+  """
+console.log(EpicClass.myName)
+console.log(EpicClass.stats.accessible)
+"""
+) # I've grown tired of manually writing the AST :(
+
+let program = parser.parse()
+print program
+
+addHandler newColoredLogger()
+setLogFilter(lvlAll)
+
+type
+  Stats* = object
+    accessible*: string = "Yes, perhaps."
+
+  EpicClass* = object
+    myName*: string = "Deine Mutter"
+    stats*: Stats
+
+var runtime = newRuntime("t001.js", program)
+runtime.registerType(prototype = EpicClass, name = "EpicClass")
+runtime.defineFn(
+  EpicClass,
+  "die",
+  proc() =
+    quit "Oooops! You killed the engine by invoking that!"
+  ,
+)
+runtime.run()

--- a/tests/runtime/val_wrap.nim
+++ b/tests/runtime/val_wrap.nim
@@ -1,0 +1,8 @@
+import std/tables
+import bali/runtime/atom_helpers
+import pretty
+
+print wrap(3)
+print wrap(":^)")
+print wrap(@[3, 4, 5])
+print wrap(@[3.wrap, ":^)".wrap, @[3, 4, 5].wrap])

--- a/tests/runtime/val_wrap.nim
+++ b/tests/runtime/val_wrap.nim
@@ -6,3 +6,13 @@ print wrap(3)
 print wrap(":^)")
 print wrap(@[3, 4, 5])
 print wrap(@[3.wrap, ":^)".wrap, @[3, 4, 5].wrap])
+
+type
+  NestedType* = object
+    hi*: string = "Hi there!"
+
+  EpicClass* = object
+    name*: string = "A very epic class"
+    nested*: NestedType
+
+print wrap(EpicClass())


### PR DESCRIPTION
- **(add) runtime: add `wrap()`**
- **(fix) runtime: initialize types with their default values instead of `undefined`**
- **(fix) grammar/\*: parse nested fields**
- **(add) runtime/atom_helpers: add `wrap` function for objects**
- **(fix) runtime: wrap member primitive, not name**
- **(add) tests: add nested field access tests**
- **(add) runtime/emitter: add codegen for nested field access**
- **(fmt) format code**
- **(xxx) update README.md**

Previously, if we had a class in JS land, we could only access its fields, not its children's fields. \
This PR allows the parser to properly parse nested fields and allows the interpreter to correctly emit code that works with nested fields. \
Hopefully, nothing breaks (nothing's broken from my testing).
