### PR TITLE
Optimization spree

### DIFF
--- a/src/balde.nim
+++ b/src/balde.nim
@@ -57,7 +57,8 @@ proc allocRuntime*(ctx: Input, file: string, ast: AST, repl: bool = false): Runt
       dumpBytecode: ctx.enabled("dump-bytecode", "D"),
       repl: repl,
       codegen: CodegenOpts(
-        elideLoops: not ctx.enabled("disable-loop-elision")
+        elideLoops: not ctx.enabled("disable-loop-elision"),
+        loopAllocationEliminator: not ctx.enabled("disable-loop-allocation-elim")
       )
     )
   )
@@ -305,8 +306,11 @@ Options:
   --dump-tokens, -T                       Dump tokens for the provided file.
   --dump-ast                              Dump the abstract syntax tree for the JavaScript file.
   --dump-no-eval                          Dump the abstract syntax tree for the JavaScript file, bypassing the IR generation phase entirely.
-  --disable-loop-elision                  Don't attempt to elide loops in the IR generation phase.
   --enable-experiments:<a>;<b>; ... <z>   Enable certain experimental features that aren't stable yet.
+
+Codegen Flags:
+  --disable-loop-elision                  Don't attempt to elide loops in the IR generation phase.
+  --disable-loop-allocation-elim          Don't attempt to rewrite loops to avoid unnecessary atom allocations
 """ % [
   name, Version
   ]

--- a/src/bali/runtime/optimize/redundant_loop_allocations.nim
+++ b/src/bali/runtime/optimize/redundant_loop_allocations.nim
@@ -1,0 +1,46 @@
+## The main routine of this module needs to be called each time a loop body is about to be generated.
+## It performs an optimization pass over it to see if there's any redundant loop allocations.
+##
+## For instance, in pseudocode:
+## while true do
+##allocate "hello world" at [1]
+##   print [1]
+## end
+##
+## This can be optimized away to:
+## allocate "hello world" at [1]
+## while true do
+##   print [1]
+## end
+
+import std/[logging]
+import mirage/atom
+import mirage/ir/generator
+import bali/grammar/prelude
+import bali/runtime/[statement_utils, types]
+
+type
+  AllocationEliminatorResult* = object
+    placeBefore*: Scope ## All statements here are to be placed outside the loop
+    modifiedBody*: Scope ## This is the modified body and it should be placed where the original body was intended
+
+proc eliminateRedundantLoopAllocations*(
+  runtime: Runtime,
+  body: Scope
+): AllocationEliminatorResult =
+  debug "redundant_loop_allocations: checking if redundant allocations can be eliminated in loop body..."
+
+  var elims: AllocationEliminatorResult
+  elims.placeBefore = Scope()
+  elims.modifiedBody = Scope()
+
+  for stmt in body.stmts:
+    case stmt.kind
+    of CreateImmutVal, CreateMutVal:
+      debug "redundant_loop_allocations: moving " & $stmt.kind & " into place-before scope"
+      elims.placeBefore.stmts &= stmt
+    else:
+      debug "redundant_loop_allocations: moving " & $stmt.kind & " into modified-body scope"
+      elims.modifiedBody.stmts &= stmt
+
+  elims

--- a/src/bali/runtime/types.nim
+++ b/src/bali/runtime/types.nim
@@ -52,6 +52,7 @@ type
 
   CodegenOpts* = object
     elideLoops*: bool = true
+    loopAllocationEliminator*: bool = true
 
   InterpreterOpts* = object
     test262*: bool = false

--- a/tests/data/string-intern-001.js
+++ b/tests/data/string-intern-001.js
@@ -4,5 +4,7 @@ var i = 0
 
 while (i < 99999)
 {
+	let str = "Hello string-interner!"
+	console.log(str)
 	i++
 }

--- a/tests/data/string-intern-001.js
+++ b/tests/data/string-intern-001.js
@@ -1,0 +1,8 @@
+// Optimization Opportunity: Instead of allocating this string 99999 times, why not just allocate it outside the loop's body?
+
+var i = 0
+
+while (i < 99999)
+{
+	i++
+}

--- a/tests/tredundantloopalloc.nim
+++ b/tests/tredundantloopalloc.nim
@@ -1,0 +1,19 @@
+import bali/runtime/optimize/redundant_loop_allocations
+import bali/runtime/prelude
+import bali/grammar/prelude
+import pkg/pretty
+
+let x = eliminateRedundantLoopAllocations(
+  runtime = nil,
+  body = Scope(
+    stmts: @[
+      Statement(
+        kind: CreateImmutVal,
+        imIdentifier: "meow",
+        imAtom: str "hi :3"
+      ),
+      callFunction("deine_mutter").call(@[CallArg(kind: cakIdent, ident: "meow")])
+    ]
+  )
+)
+print x


### PR DESCRIPTION
- **(add) runtime: implement loop allocation eliminator**
- **(add) runtime: plug in loop allocation eliminator**
- **(fix) runtime: don't allocate constants for every scope**
- **(add) balde: add --disable-loop-allocation-elim**
- **(xxx) manual: add optimization section**

Loops no longer allocate memory unnecessarily, meaning infinite loops work properly now (a bug in the IR generator would make them allocate constants even when they didn't need to).

All unnecessary allocations inside loops are now moved outside the body to reduce pressure on the GC and to reduce a program's memory footprint significantly.
