### PR TITLE
Add support for BigInt

### DIFF
--- a/bali.nimble
+++ b/bali.nimble
@@ -13,7 +13,7 @@ binDir          = "bin"
 # Dependencies
 
 requires "nim >= 2.0.2"
-requires "mirage >= 1.0.44"
+requires "mirage >= 1.1.0"
 requires "librng >= 0.1.3"
 requires "pretty >= 0.1.0"
 requires "colored_logger >= 0.1.0"
@@ -30,3 +30,5 @@ requires "https://github.com/xTrayambak/kaleidoscope >= 0.1.1"
 taskRequires "fmt", "nph#master"
 task fmt, "Format code":
   exec "nph src/ tests/"
+
+requires "https://github.com/ferus-web/nim-gmp >= 0.1.0"

--- a/src/bali/runtime/abstract/coercion.nim
+++ b/src/bali/runtime/abstract/coercion.nim
@@ -3,4 +3,4 @@
 
 import ./[coercible, to_number, to_primitive, to_string]
 
-export coercible, to_number, to_string
+export coercible, to_number, to_string, to_primitive

--- a/src/bali/runtime/abstract/to_number.nim
+++ b/src/bali/runtime/abstract/to_number.nim
@@ -1,4 +1,4 @@
-import std/[logging]
+import std/[logging, math]
 import mirage/runtime/prelude
 import bali/internal/sugar
 import bali/runtime/[atom_helpers, types]
@@ -54,3 +54,25 @@ proc ToNumber*(runtime: Runtime, value: MAtom): float =
     return &value.getFloat()
   else:
     unreachable
+
+proc isFiniteNumber*(runtime: Runtime, number: MAtom): bool {.inline.} =
+  if not isNumber(number):
+    return false
+
+  let value = runtime.ToNumber(number)
+
+  if value.int32 < int32.high:
+    return true
+
+  return value != NaN and value != Inf
+
+proc isIntegralNumber*(runtime: Runtime, number: MAtom): bool {.inline.} =
+  if not number.isNumber:
+    return false
+
+  let value = runtime.ToNumber(number)
+
+  if value.int32 < int32.high:
+    return true
+
+  runtime.isFiniteNumber(number) and value.trunc() == value

--- a/src/bali/runtime/abstract/to_primitive.nim
+++ b/src/bali/runtime/abstract/to_primitive.nim
@@ -40,14 +40,14 @@ proc OrdinaryToPrimitive*(runtime: Runtime, input: MAtom, hint: PrimitiveHint): 
 
   # 4. Throw a TypeError exception.
   # Yes Rico, kaboom.
-  # runtime.typeError("Cannot convert object into primitive")
+  runtime.typeError("Cannot convert object into primitive")
 
 proc ToPrimitive*(runtime: Runtime, input: MAtom, preferredType: Option[MAtomKind] = none(MAtomKind)): MAtom =
   # 1. If input is an Object, then
   if input.kind == Object:
     # a. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
     let exoticToPrim = runtime.getMethod(input, "toPrimitive")
- 
+
     if *exoticToPrim:
       # b. If exoticToPrim is not undefined, then
       
@@ -65,7 +65,7 @@ proc ToPrimitive*(runtime: Runtime, input: MAtom, preferredType: Option[MAtomKin
           # 1. Assert: preferredType is number.
           if &preferredType in [Integer, UnsignedInt, Float]:
             # 2. Let hint be "number".
-            PrimitiveHint.String
+            PrimitiveHint.Number
           else:
             unreachable
             default PrimitiveHint
@@ -80,8 +80,10 @@ proc ToPrimitive*(runtime: Runtime, input: MAtom, preferredType: Option[MAtomKin
         return &res
       else:
         # vi. Throw a TypeError exception.
-        # runtime.typeError("Cannot convert object into primitive")
-        discard
+        runtime.typeError("Cannot convert object into primitive")
     else:
       # c. If preferredType is not present, let preferredType be number.
       return runtime.OrdinaryToPrimitive(input, PrimitiveHint.Number)
+
+  # 2. Return input.
+  return input

--- a/src/bali/runtime/abstract/to_string.nim
+++ b/src/bali/runtime/abstract/to_string.nim
@@ -4,6 +4,7 @@ import bali/internal/sugar
 import bali/runtime/[atom_helpers, types]
 import bali/runtime/abstract/to_primitive
 import bali/stdlib/errors
+import pkg/gmp
 import pretty
 
 proc ToString*(runtime: Runtime, value: MAtom): string =
@@ -41,6 +42,10 @@ proc ToString*(runtime: Runtime, value: MAtom): string =
     return
       $(&value.getInt())
         # 7. If argument is a Number, return Number::toString(argument, 10).
+  of BigInteger:
+    debug "runtime: toString(): atom is a bigint"
+    return
+      $value.bigint
   of Float:
     debug "runtime: toString(): atom is a number (float)."
     return
@@ -64,4 +69,3 @@ proc ToString*(runtime: Runtime, value: MAtom): string =
     buffer &= ']'
 
     return buffer
-

--- a/src/bali/runtime/atom_helpers.nim
+++ b/src/bali/runtime/atom_helpers.nim
@@ -18,6 +18,9 @@ func isNumber*(atom: MAtom): bool {.inline.} =
   atom.kind == UnsignedInt or
   atom.kind == Integer
 
+func isBigInt*(atom: MAtom): bool {.inline.} =
+  atom.kind == BigInteger
+
 proc `[]`*(atom: MAtom, name: string): MAtom {.inline.} =
   if atom.kind != Object:
     raise newException(ValueError, $atom.kind & " does not have field access methods")

--- a/src/bali/runtime/interpreter.nim
+++ b/src/bali/runtime/interpreter.nim
@@ -237,6 +237,8 @@ proc generateIR*(
     parentStmt: Option[Statement] = none(Statement),
     index: Option[uint] = none(uint)
 ) =
+  ## Given a statement `stmt` and its encompassing functional scope `fn` (which can be a plain scope as well),
+  ## generate the bytecode for that statement.
   case stmt.kind
   of CreateImmutVal:
     debug "emitter: generate IR for creating immutable value with identifier: " &
@@ -999,6 +1001,7 @@ proc run*(runtime: Runtime) =
   encodeUri.generateStdIR(runtime)
   std_string.generateStdIR(runtime)
   date.generateStdIR(runtime)
+  std_bigint.generateStdIR(runtime)
 
   parseIntGenerateStdIR(runtime)
 

--- a/src/bali/runtime/types.nim
+++ b/src/bali/runtime/types.nim
@@ -225,6 +225,7 @@ proc loadIRAtom*(runtime: Runtime, atom: MAtom): uint =
       inc runtime.addrIdx
       let idx = runtime.loadIRAtom(item)
       runtime.ir.appendList(result, idx)
+  else: unreachable
 
 proc index*(runtime: Runtime, ident: string, params: IndexParams): uint =
   for value in runtime.values:

--- a/src/bali/stdlib/prelude.nim
+++ b/src/bali/stdlib/prelude.nim
@@ -1,6 +1,6 @@
 import ./[console, math, uri, errors, errors_ir, errors_common, json, constants, date]
 import ./builtins/[base64, parse_int, test262, encode_uri]
-import ./types/[std_string]
+import ./types/[std_string, std_bigint]
 
 export console, math, uri, parse_int, errors, test262, base64, json, constants, date,
-       encode_uri, errors_ir, errors_common, std_string
+       encode_uri, errors_ir, errors_common, std_string, std_bigint

--- a/src/bali/stdlib/types/std_bigint.nim
+++ b/src/bali/stdlib/types/std_bigint.nim
@@ -1,0 +1,132 @@
+## Arbitrary-precision integers
+import std/[logging, options, tables]
+import bali/runtime/[arguments, atom_helpers, types, bridge]
+import bali/runtime/abstract/coercion
+import bali/stdlib/errors
+import bali/internal/[sugar, trim_string]
+import mirage/atom
+import pkg/[pretty, gmp]
+
+type
+  JSBigInt* = object
+    `@value`*: MAtom
+
+proc stringToBigInt*(runtime: Runtime, str: MAtom): MAtom =
+  # 7.1.14 StringToBigInt ( str )
+
+  # 1. Let text be StringToCodePoints(str).
+  let text = runtime.trimString(str, TrimMode.Both)
+
+  var bigint =
+    try:
+      # 2. Let literal be ParseText(text, StringIntegerLiteral).
+      bigint(text)
+    except ValueError:
+      # 3. If literal is a List of errors, return undefined.
+      undefined()
+
+  # 6. Return ℤ(mv).
+  var bigintAtom = runtime.createObjFromType(JSBigInt)
+  bigintAtom.tag("value", move(bigint))
+
+  move(bigintAtom)
+
+proc toBigInt*(runtime: Runtime, atom: MAtom): MAtom =
+  ## 7.1.13 ToBigInt ( argument ), https://tc39.es/ecma262/#sec-tobigint
+
+  # 1. Let prim be ? ToPrimitive(argument, number).
+  let prim = runtime.ToPrimitive(atom, some(Integer))
+
+  # 2. Return the value that prim corresponds to in Table 12.
+
+  # Number
+  if prim.isNumber():
+    # Throw a TypeError exception.
+    runtime.typeError("Cannot convert number into BigInt")
+  
+  # BigInt
+  if prim.kind == BigInteger:
+    # Return prim.
+    var bigint = runtime.createObjFromType(JSBigInt)
+    bigint.tag("value", prim)
+    return bigint
+  
+  # String
+  if prim.kind == String:
+    # 1. Let n be StringToBigInt(prim).
+    let n = runtime.stringToBigInt(prim)
+
+    if n.isUndefined():
+      # 2. If n is undefined, throw a SyntaxError exception.
+      runtime.syntaxError("invalid BigInt syntax")
+    
+    # 3. Return n
+    return n
+  
+  # Null
+  if prim.isNull():
+    # Throw a TypeError exception.
+    runtime.typeError("can't convert null to BigInt")
+  
+  # Undefined
+  if prim.isUndefined():
+    # Throw a TypeError exception.
+    runtime.typeError("can't convert undefined to BigInt")
+
+  # Boolean
+  if prim.kind == Boolean:
+    # Return 1n if prim is true and 0n if prim is false.
+
+    var bigint = runtime.createObjFromType(JSBigInt)
+    bigint.tag("value", bigint(int(&prim.getBool())))
+    return bigint
+
+proc numberToBigInt*(runtime: Runtime, primitive: MAtom): MAtom {.inline.} =
+  ## 21.2.1.1.1 NumberToBigInt ( number )
+  
+  # 1. If IsIntegralNumber(number) is false, throw a RangeError exception.
+  if not runtime.isIntegralNumber(primitive):
+    runtime.rangeError("Value is out of the valid range")
+  
+  # 2. Return ℤ(ℝ(number)).
+
+  var bigint = runtime.createObjFromType(JSBigInt)
+
+  bigint.tag("value", bigint(
+    runtime.ToNumber(
+      primitive
+    ).int()
+  ))
+
+  bigint
+
+proc generateStdIR*(runtime: Runtime) =
+  runtime.registerType(prototype = JSBigInt, name = "BigInt")
+  runtime.defineFn(
+    "BigInt",
+    proc =
+      ## 21.2.1.1 BigInt ( value )
+
+      # 1. If NewTarget is not undefined, throw a TypeError exception.
+      # TODO: I have no clue what NewTarget is.
+      
+      let value = &runtime.argument(1)
+
+      # 2. Let prim be ? ToPrimitive(value, NUMBER).
+      let primitive = runtime.ToPrimitive(value, some(Integer))
+      
+      # 3. If Type(prim) is Number, return ? NumberToBigInt(prim).
+      if primitive.isNumber():
+        ret runtime.numberToBigInt(primitive)
+      
+      # 4. Otherwise, return ? ToBigInt(prim).
+      ret runtime.toBigInt(primitive)
+  )
+
+  runtime.definePrototypeFn(
+    JSBigInt,
+    "toString",
+    proc(value: MAtom) =
+      let bigint = &value.tagged("value")
+      ret $bigint.bigint
+  )

--- a/src/bali/stdlib/types/std_string.nim
+++ b/src/bali/stdlib/types/std_string.nim
@@ -3,7 +3,7 @@
 ## Author(s):
 ## Trayambak Rai (xtrayambak at disroot dot org)
 import std/[logging, tables, strutils, hashes, unicode]
-import bali/runtime/[arguments, bridge, atom_helpers, types, bridge]
+import bali/runtime/[arguments, bridge, atom_helpers, types]
 import bali/runtime/abstract/[coercible, to_number, to_string]
 import bali/stdlib/errors
 import bali/internal/[trim_string, sugar]

--- a/tests/data/bigint-001.js
+++ b/tests/data/bigint-001.js
@@ -1,0 +1,2 @@
+let x = BigInt("23")
+console.log(x)

--- a/tests/data/make-stuff-hit-the-fan-001.js
+++ b/tests/data/make-stuff-hit-the-fan-001.js
@@ -1,0 +1,8 @@
+var i = 0;
+
+while (i < 99999999)
+{
+	let x = BigInt("32")
+	console.log(x)
+	i++
+}


### PR DESCRIPTION
- **(fix) abstract: export `ToPrimitive()`**
- **(bump) mirage: 1.0.44 -> 1.1.0**
- **(fix) stdlib: fix cyclic import**
- **(add) runtime: add `isBigInt()`**
- **(add) stdlib: implement `JSBigInt`**
- **(fix) stdlib: `ToPrimitive()` raises errors on failure**
- **(add) runtime: `isFiniteNumber()` and `isIntegralNumber()`**
- **(add) runtime: `ToString()` now handles `BigInt` properly**

This PR implements some parts of the `BigInt` type, as the specification says. `BigInt`(s) are arbitrary-precision integers. Mirage has been bumped to 1.1.0, as that release adds support for `BigInteger` atoms into the VM.
