### PR TITLE
Implement functions as atoms

### DIFF
--- a/src/bali/runtime/types.nim
+++ b/src/bali/runtime/types.nim
@@ -263,6 +263,9 @@ proc loadIRAtom*(runtime: Runtime, atom: MAtom): uint =
 proc index*(runtime: Runtime, ident: string, params: IndexParams): uint =
   for value in runtime.values:
     for prio in params.priorities:
+      if value.kind == vkGlobal and value.identifier == ident:
+        return value.index
+
       if value.kind != prio:
         continue
 
@@ -279,7 +282,7 @@ proc index*(runtime: Runtime, ident: string, params: IndexParams): uint =
 
       if cond:
         return value.index
-
+  
   debug "runtime: cannot find identifier \"" & ident &
     "\" in index search, returning pointer to undefined()"
   runtime.index("undefined", params)

--- a/src/bali/stdlib/constants.nim
+++ b/src/bali/stdlib/constants.nim
@@ -19,23 +19,25 @@ proc generateStdIr*(runtime: Runtime) =
 
   runtime.constantsGenerated = true
 
+  let params = IndexParams(priorities: @[vkGlobal])
+
   debug "constants: generating constant values"
-  runtime.ir.loadObject(runtime.addrIdx)
-  runtime.ir.markGlobal(runtime.addrIdx)
-  runtime.markGlobal("undefined")
-
-  runtime.ir.loadFloat(runtime.addrIdx, floating(NaN))
-  runtime.ir.markGlobal(runtime.addrIdx)
-  runtime.markGlobal("NaN")
-
-  runtime.ir.loadBool(runtime.addrIdx, true)
-  runtime.ir.markGlobal(runtime.addrIdx)
-  runtime.markGlobal("true")
-
-  runtime.ir.loadBool(runtime.addrIdx, false)
-  runtime.ir.markGlobal(runtime.addrIdx)
-  runtime.markGlobal("false")
-
-  runtime.ir.loadNull(runtime.addrIdx)
-  runtime.ir.markGlobal(runtime.addrIdx)
-  runtime.markGlobal("null")
+  let undefined = runtime.index("undefined", params)
+  runtime.ir.loadObject(undefined)
+  runtime.ir.markGlobal(undefined)
+  
+  let nan = runtime.index("NaN", params)
+  runtime.ir.loadFloat(nan, floating(NaN))
+  runtime.ir.markGlobal(nan)
+  
+  let vTrue = runtime.index("true", params)
+  runtime.ir.loadBool(vTrue, true)
+  runtime.ir.markGlobal(vTrue)
+  
+  let vFalse = runtime.index("false", params)
+  runtime.ir.loadBool(vFalse, false)
+  runtime.ir.markGlobal(vFalse)
+  
+  let null = runtime.index("null", params)
+  runtime.ir.loadNull(null)
+  runtime.ir.markGlobal(null)

--- a/tests/data/func-as-value-001.js
+++ b/tests/data/func-as-value-001.js
@@ -1,5 +1,6 @@
 function callSomething(x) {
-	console.log("Upon calling the given function, I got:", x())
+	// console.log(x)
+	console.log(x)
 }
 
 function cheezburgr() {


### PR DESCRIPTION
This allows for references to functions to be passed around to different
functions, as if they were regular JavaScript values. You cannot invoke
them yet, though.
