### PR TITLE
Fix multiple call arguments

### DIFF
--- a/src/bali/runtime/interpreter.nim
+++ b/src/bali/runtime/interpreter.nim
@@ -231,7 +231,6 @@ proc generateIRForScope*(runtime: Runtime, scope: Scope, allocateConstants: bool
 
 func willIRGenerateClause*(runtime: Runtime, clause: string): bool {.inline.} =
   for cls in runtime.ir.modules:
-    debugecho "> " & cls.name
     if cls.name == clause:
       return true
 
@@ -311,7 +310,7 @@ proc generateIR*(
         runtime.ir.passArgument(
           runtime.index((&stmt.fn.field).identifier, defaultParams(fn))
         )
-
+    
     for i, arg in stmt.arguments:
       case arg.kind
       of cakIdent:
@@ -970,9 +969,10 @@ proc loadArgumentsOntoStack*(runtime: Runtime, fn: Function) =
   for i, arg in fn.arguments:
     runtime.markLocal(fn, arg)
     runtime.ir.readRegister(
-      runtime.index(arg, defaultParams(fn)), Register.CallArgument
+      runtime.index(arg, defaultParams(fn)), i.uint, Register.CallArgument
     )
-    runtime.ir.resetArgs() # reset the call param register
+
+  runtime.ir.resetArgs() # reset the call param register
 
 proc generateIRForScope*(
     runtime: Runtime, scope: Scope, allocateConstants: bool = true

--- a/src/bali/runtime/vm/runtime/pulsar/interpreter.nim
+++ b/src/bali/runtime/vm/runtime/pulsar/interpreter.nim
@@ -2,7 +2,7 @@
 ## into a more modular and efficient form. You shouldn't import this directly, import `mirage/interpreter/prelude` instead.
 ##
 
-import std/[math, tables, options]
+import std/[math, tables, options, logging]
 import bali/runtime/vm/heap/boehm
 import bali/runtime/vm/[atom, utils]
 import bali/runtime/vm/runtime/[shared, tokenizer, exceptions]
@@ -925,8 +925,9 @@ proc execute*(interpreter: var PulsarInterpreter, op: var Operation) =
       )
     of 1:
       # 1 - callargs register
+      debug "vm: read call arguments register (#1); placing index " & $(&op.arguments[1].getInt()) & " into stack position " & $idx
       interpreter.addAtom(
-        interpreter.registers.callArgs[&op.arguments[1].getInt() - 1], idx
+        interpreter.registers.callArgs[&op.arguments[1].getInt()], idx
       )
     else:
       raise newException(

--- a/tests/data/factorial.js
+++ b/tests/data/factorial.js
@@ -1,9 +1,10 @@
-function fac(n) {
-    let result = 1
-    while (n > 1) {
-        n--
-    }
-    return result
+function fac(n, acc) {
+	if (n == 0) {
+		return acc;
+	}
+
+	let value = fac(n - 1, n * acc)
+	return value
 }
 
-console.log(fac(32))
+console.log(fac(5, 1))


### PR DESCRIPTION
- **fix: parser: parse multiple arguments in function signature**
- **fix: vm: fix dynamically growing register reads**
- **fix: codegen: don't reset arguments before full load**

Fixes #86
