### PR TITLE
Native callables support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
           nim-version: '2.2.0'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       
-      - run: sudo apt-get install gcc libicu-dev libgmp-dev libgc-dev
-      - run: git clone https://github.com/simdutf/simdutf && cd simdutf && cmake . && sudo make install . -j$(nproc) && cd .. && nimble refresh && nimble build --define:release --define:baliStaticallyLinkLibICU --define:speed --out:./
+      - run: sudo apt-get install gcc libgmp-dev libgc-dev
+      - run: git clone https://github.com/simdutf/simdutf && cd simdutf && cmake . && sudo make install . -j$(nproc) && cd .. && nimble refresh && nimble build --define:release --define:baliTest262FyiDisableICULinkingCode --define:speed --out:./
 
       - name: Upload Build Artifact (balde)
         uses: actions/upload-artifact@v4

--- a/nim.cfg
+++ b/nim.cfg
@@ -7,9 +7,15 @@
 # Enable SIMD support
 --passC: "-march=znver3 -mtune=znver3 -msse -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -mpclmul -mavx -mavx2"
 
---warning:UnreachableCode:off
---warningAsError:UnusedImport:on
---warningAsError:Uninit:on
---warningAsError:ProveInit:on
+@if not release:
+  --warning:UnreachableCode:off
+  --warningAsError:UnusedImport:on
+  --warningAsError:Uninit:on
+  --warningAsError:ProveInit:on
+  --experimental:strictFuncs
+@end
 
---experimental:strictFuncs
+@if gdb:
+  --debugger:native
+  --define:useMalloc
+@end

--- a/src/bali/runtime/abstract/to_number.nim
+++ b/src/bali/runtime/abstract/to_number.nim
@@ -37,15 +37,12 @@ proc ToNumber*(runtime: Runtime, value: JSValue): float =
   of UnsignedInt:
     return float(&value.getUint())
   of Object:
-    if value.isUndefined():
-      return NaN # 3. If argument is undefined, return NaN.
-    else:
-      # 8. Let primValue be ? ToPrimitive(argument, NUMBER).
-      let primValue = runtime.ToPrimitive(value, some(Float))
-      assert(primValue.kind != Object)
+    # 8. Let primValue be ? ToPrimitive(argument, NUMBER).
+    let primValue = runtime.ToPrimitive(value, some(Float))
+    assert(primValue.kind != Object)
 
-      # 10. Return ? ToNumber(primValue)
-      return runtime.ToNumber(primValue)
+    # 10. Return ? ToNumber(primValue)
+    return runtime.ToNumber(primValue)
   of Null:
     return 0f # 4. If argument is either null or false, return +0𝔽.
   of Boolean:
@@ -57,6 +54,9 @@ proc ToNumber*(runtime: Runtime, value: JSValue): float =
     return runtime.StringToNumber(value)
   of Float:
     return &value.getFloat()
+  of Undefined:
+    # 3. If argument is undefined, return NaN.
+    return NaN
   else:
     unreachable
 

--- a/src/bali/runtime/bridge.nim
+++ b/src/bali/runtime/bridge.nim
@@ -267,7 +267,7 @@ proc typeRegistrationFinalizer*(runtime: Runtime) =
 
       capture name, fn:
         jsObj[name] = nativeCallable(
-          proc =
+          proc() =
             fn.fn()()
         )
 

--- a/src/bali/runtime/codegen.nim
+++ b/src/bali/runtime/codegen.nim
@@ -7,7 +7,7 @@ import bali/grammar/prelude
 import bali/internal/sugar
 import
   bali/runtime/[
-    normalize, types, atom_helpers, atom_obj_variant, arguments, statement_utils,
+    normalize, types, atom_helpers, arguments, statement_utils,
     bridge, describe,
   ]
 import bali/runtime/optimize/[mutator_loops, redundant_loop_allocations]
@@ -1128,27 +1128,9 @@ proc generateInternalIR*(runtime: Runtime) =
 
       if atom.kind != Object:
         debug "runtime: atom is not an object, returning undefined."
-        runtime.vm.addAtom(obj(), storeAt)
+        runtime.vm.addAtom(undefined(), storeAt)
         return
-
-      for typ in runtime.types:
-        if typ.singletonId == index:
-          debug "runtime: singleton ID for type `" & typ.name &
-            "` matches field access index"
-
-          for name, member in typ.members:
-            if member.isFn:
-              continue
-            if name != accesses.identifier:
-              continue
-
-            if accesses.next != nil:
-              assert(member.atom().kind == Object)
-              runtime.vm.addAtom(member.atom().findField(accesses.next), storeAt)
-            else:
-              runtime.vm.addAtom(member.atom(), storeAt)
-            return
-
+      
       runtime.vm.addAtom(atom.findField(accesses), storeAt),
   )
   runtime.ir.call("BALI_RESOLVEFIELD_INTERNAL")
@@ -1254,7 +1236,7 @@ proc generateInternalIR*(runtime: Runtime) =
           runtime.typeError("Value is undefined")
 
         if destAtom.isNull:
-          runtime.typeError("Value is stackNull")
+          runtime.typeError("Value is null")
 
       checkDestAtom
 

--- a/src/bali/runtime/codegen.nim
+++ b/src/bali/runtime/codegen.nim
@@ -371,7 +371,7 @@ proc generateIR*(
     let index = runtime.index(stmt.storeIdent, defaultParams(fn))
     debug "emitter: call-and-store result will be stored in ident \"" & stmt.storeIdent &
       "\" or index " & $index
-    runtime.ir.loadObject(index) # load `undefined` on that index
+    runtime.ir.loadUndefined(index) # load `undefined` on that index
     runtime.ir.readRegister(index, Register.ReturnValue)
     runtime.ir.zeroRetval()
   of ConstructObject:

--- a/src/bali/runtime/codegen.nim
+++ b/src/bali/runtime/codegen.nim
@@ -1293,7 +1293,10 @@ proc run*(runtime: Runtime) =
   json.generateStdIR(runtime)
   encodeUri.generateStdIR(runtime)
   std_string.generateStdIR(runtime)
-  date.generateStdIR(runtime)
+
+  when not defined(baliTest262FyiDisableICULinkingCode):
+    date.generateStdIR(runtime)
+
   std_bigint.generateStdIR(runtime)
   std_number.generateStdIR(runtime)
   std_set.generateStdIR(runtime)

--- a/src/bali/runtime/codegen.nim
+++ b/src/bali/runtime/codegen.nim
@@ -6,10 +6,8 @@ import bali/runtime/vm/runtime/[tokenizer, prelude]
 import bali/grammar/prelude
 import bali/internal/sugar
 import
-  bali/runtime/[
-    normalize, types, atom_helpers, arguments, statement_utils,
-    bridge, describe,
-  ]
+  bali/runtime/
+    [normalize, types, atom_helpers, arguments, statement_utils, bridge, describe]
 import bali/runtime/optimize/[mutator_loops, redundant_loop_allocations]
 import bali/runtime/vm/heap/boehm
 import bali/runtime/abstract/equating
@@ -1130,7 +1128,7 @@ proc generateInternalIR*(runtime: Runtime) =
         debug "runtime: atom is not an object, returning undefined."
         runtime.vm.addAtom(undefined(), storeAt)
         return
-      
+
       runtime.vm.addAtom(atom.findField(accesses), storeAt),
   )
   runtime.ir.call("BALI_RESOLVEFIELD_INTERNAL")

--- a/src/bali/runtime/vm/atom.nim
+++ b/src/bali/runtime/vm/atom.nim
@@ -196,6 +196,10 @@ proc getSequence*(atom: MAtom | JSValue): Option[seq[MAtom]] {.inline.} =
   if atom.kind == Sequence:
     return some(atom.sequence)
 
+proc getNativeCallable*(atom: MAtom | JSValue): Option[proc()] {.inline.} =
+  if atom.kind == NativeCallable:
+    return some(atom.fn)
+
 proc newJSValue*(kind: MAtomKind): JSValue =
   ## Allocate a new `JSValue` using Bali's garbage collector.
   ## A `JSValue` is a pointer to an atom.
@@ -219,7 +223,6 @@ func stackStr*(s: string): MAtom =
   MAtom(kind: String, str: s)
 
 proc ident*(ident: string): JSValue {.inline.} =
-  assert off
   var mem = newJSValue(Ident)
   mem.ident = ident
 

--- a/src/bali/runtime/vm/runtime/pulsar/interpreter.nim
+++ b/src/bali/runtime/vm/runtime/pulsar/interpreter.nim
@@ -1131,8 +1131,12 @@ proc execute*(interpreter: var PulsarInterpreter, op: var Operation) =
         interpreter.call(&getBytecodeClause(callable), op)
       elif callable.kind == NativeCallable:
         callable.fn()
+      else:
+        raise newException(ValueError, "INVK cannot deal with atom: " & $callable.kind)
     elif value.kind == String:
       interpreter.call(&getStr(value), op)
+    else:
+      raise newException(ValueError, "INVK cannot deal with atom: " & $value.kind)
 
     inc interpreter.currIndex
   else:

--- a/src/bali/stdlib/console.nim
+++ b/src/bali/stdlib/console.nim
@@ -1,7 +1,7 @@
 ## JavaScript console API standard interface
 ## This uses a delegate system similar to that of V8's.
 
-import std/[options, logging]
+import std/[options, logging, tables]
 import bali/runtime/vm/runtime/prelude
 import bali/runtime/[arguments, types, bridge]
 import bali/runtime/abstract/coercion

--- a/src/bali/stdlib/prelude.nim
+++ b/src/bali/stdlib/prelude.nim
@@ -1,7 +1,11 @@
-import ./[console, math, uri, errors, errors_ir, errors_common, json, constants, date]
+import ./[console, math, uri, errors, errors_ir, errors_common, json, constants]
 import ./builtins/[base64, parse_int, test262, encode_uri]
 import ./types/[std_string, std_bigint, std_number, std_set]
 
 export
-  console, math, uri, parse_int, errors, test262, base64, json, constants, date,
+  console, math, uri, parse_int, errors, test262, base64, json, constants,
   encode_uri, errors_ir, errors_common, std_string, std_bigint, std_number, std_set
+
+when not defined(baliTest262FyiDisableICULinkingCode):
+  import ./date
+  export date

--- a/src/bali/stdlib/types/std_string.nim
+++ b/src/bali/stdlib/types/std_string.nim
@@ -96,7 +96,7 @@ proc generateStdIr*(runtime: Runtime) =
       # 8. Return 𝔽(StringIndexOf(S, searchStr, start)).
       if value.len < BaliStringAccelerationThreshold:
         ret strutils.find(value[start ..< value.len], searchStr)
-          # Don't use SIMD acceleration if a string is smaller than 512 characters
+          # Optimization: Don't use SIMD acceleration if a string is smaller than 512 characters
       else:
         ret search.find(value[start ..< value.len], searchStr)
     ,
@@ -147,6 +147,7 @@ proc generateStdIr*(runtime: Runtime) =
     ## 22.1.3.34 String.prototype.trimStart ( )
     ## B.2.2.15 String.prototype.trimLeft ( )       [ LEGACY VERSION, USE 22.1.3.34 INSTEAD! ]
 
+
     # 1. Let S be the this value.
     let value = &value.tagged("internal")
 
@@ -156,6 +157,7 @@ proc generateStdIr*(runtime: Runtime) =
   proc trimEnd(value: JSValue) =
     ## 22.1.3.33 String.prototype.trimEnd ( )
     ## B.2.2.16 String.prototype.trimRight ( )     [ LEGACY VERSION, USE 22.1.3.33 INSTEAD! ]
+    
 
     # 1. Let S be the this value.
     let value = &value.tagged("internal")
@@ -257,13 +259,6 @@ proc generateStdIr*(runtime: Runtime) =
       # Return 𝔽(cp.[[CodePoint]]).
       ret codepoint
     ,
-  )
-
-  runtime.definePrototypeFn(
-    JSString,
-    "turnIntoInt",
-    proc(value: JSValue) =
-      value[] = integer(1337)[],
   )
 
   #[ runtime.definePrototypeFn(

--- a/src/bali/stdlib/types/std_string.nim
+++ b/src/bali/stdlib/types/std_string.nim
@@ -147,7 +147,6 @@ proc generateStdIr*(runtime: Runtime) =
     ## 22.1.3.34 String.prototype.trimStart ( )
     ## B.2.2.15 String.prototype.trimLeft ( )       [ LEGACY VERSION, USE 22.1.3.34 INSTEAD! ]
 
-
     # 1. Let S be the this value.
     let value = &value.tagged("internal")
 
@@ -157,7 +156,6 @@ proc generateStdIr*(runtime: Runtime) =
   proc trimEnd(value: JSValue) =
     ## 22.1.3.33 String.prototype.trimEnd ( )
     ## B.2.2.16 String.prototype.trimRight ( )     [ LEGACY VERSION, USE 22.1.3.33 INSTEAD! ]
-    
 
     # 1. Let S be the this value.
     let value = &value.tagged("internal")


### PR DESCRIPTION
- **fix: codegen: load `undefined`, not an empty `Object` as read register stub**
- **fix: `ToNumber()` now recognizes the new `undefined` type**
- **add: vm: native function callables**
- **chore: fmt**

Instead of a weird field resolution hack, atoms now hold their properties as bytecode segment references AND native callables that are invokable by the same VM opcode. This brings us one step closer to becoming a full JavaScript engine.
