### PR TITLE
Modification of prototype functions should work; fixes #104

### DIFF
--- a/nim.cfg
+++ b/nim.cfg
@@ -1,5 +1,4 @@
 --deepCopy:on
-# --define:useMimalloc
 
 # Bali-specific flags
 # --define:baliUseStdBase64 # Instead of simdutf's SIMD accelerated base64 encoder/decoder, use the (slower) ones in the Nim standard library.
@@ -18,4 +17,6 @@
 @if gdb:
   --debugger:native
   --define:useMalloc
+else:
+  --define:useMimalloc
 @end

--- a/src/balde.nim
+++ b/src/balde.nim
@@ -319,6 +319,7 @@ proc baldeRepl(ctx: Input) =
       runtime.values = prevRuntime.values
       runtime.vm.stack = prevRuntime.vm.stack
         # Copy all atoms of the previous runtime to the new one
+
     runtime.run()
     prevRuntime = runtime
 

--- a/src/balde.nim
+++ b/src/balde.nim
@@ -313,8 +313,7 @@ proc baldeRepl(ctx: Input) =
   var prevRuntime: Runtime
   var noise = Noise.init()
 
-  template evaluateSource(line: string) =
-    let ast = newParser(line).parse()
+  template evaluateSource(ast: AST) =
     var runtime = allocRuntime(ctx, "<repl>", ast, repl = true)
     if prevRuntime != nil:
       runtime.values = prevRuntime.values
@@ -422,7 +421,7 @@ You can also just type in JavaScript expressions to evaluate them."""
             )
         else:
           noise.historyAdd(line)
-          evaluateSource line
+          evaluateSource ast
 
   when promptHistory:
     discard noise.historySave(file)

--- a/src/bali/runtime/abstract/to_primitive.nim
+++ b/src/bali/runtime/abstract/to_primitive.nim
@@ -1,5 +1,5 @@
-import std/[options, tables]
-import bali/runtime/[types, atom_helpers, bridge]
+import std/[options]
+import bali/runtime/[types, bridge]
 import bali/internal/sugar
 import bali/stdlib/errors
 import bali/runtime/vm/runtime/prelude
@@ -31,7 +31,7 @@ proc OrdinaryToPrimitive*(
       continue
 
     # b. If IsCallable(method) is true, then
-    (&meth)(input)
+    (&meth)()
     # i. Let result be ? Call(method, O).
     let res = runtime.getReturnValue()
 
@@ -74,7 +74,7 @@ proc ToPrimitive*(
             default PrimitiveHint
 
       # iv. Let result be ? Call(exoticToPrim, input, « hint »).
-      (&exoticToPrim)(wrap(toTable {"hint": hint.int.integer(), "input": input}))
+      (&exoticToPrim)() # wrap(toTable {"hint": hint.int.integer(), "input": input}))
       let res = runtime.getReturnValue()
       assert(*res, "BUG: Expected toPrimitive() to return value, got nothing.")
 

--- a/src/bali/runtime/codegen.nim
+++ b/src/bali/runtime/codegen.nim
@@ -1127,6 +1127,9 @@ proc generateInternalIR*(runtime: Runtime) =
           )()
         )
 
+      debug "hooks: BALI_RESOLVEFIELD_INTERNAL: index = " & $index & ", destination = " &
+        $storeAt
+
       let atom = &runtime.vm.get(index)
 
       if atom.isUndefined():

--- a/src/bali/runtime/codegen.nim
+++ b/src/bali/runtime/codegen.nim
@@ -282,6 +282,7 @@ proc generateIR*(
       runtime.markInternal(&ownerStmt, stmt.mutIdentifier)
   of Call:
     runtime.expand(fn, stmt)
+    runtime.ir.resetArgs()
     var nam =
       if stmt.mangle:
         stmt.fn.normalizeIRName()
@@ -1130,21 +1131,8 @@ proc generateInternalIR*(runtime: Runtime) =
     proc(op: Operation) =
       inc runtime.statFieldAccesses
       let
-        idxAtom = &runtime.argument(1)
-
-        index =
-          if idxAtom.kind == Integer:
-            (&idxAtom.getInt()).uint()
-          else:
-            &idxAtom.getUint()
-
-        storeAtAtom = &runtime.argument(2)
-
-        storeAt =
-          if idxAtom.kind == Integer:
-            (&storeAtAtom.getInt()).uint()
-          else:
-            &storeAtAtom.getUint()
+        index = uint(&getInt(&runtime.argument(1)))
+        storeAt = uint(&getInt(&runtime.argument(2)))
 
         accesses = createFieldAccess(
           (

--- a/src/bali/runtime/codegen.nim
+++ b/src/bali/runtime/codegen.nim
@@ -700,7 +700,14 @@ proc generateIR*(
     )
     let dest = runtime.addrIdx - 1
 
-    runtime.ir.copyAtom(runtime.index(stmt.cpMutSourceIdent, defaultParams(fn)), dest)
+    if stmt.cpMutDestIdent.contains('.'):
+      # Field access.
+      let fields = createFieldAccess(stmt.cpMutDestIdent.split('.'))
+
+      # TODO: recursively find the field to modify
+      runtime.ir.writeField(runtime.index(fields.identifier, defaultParams(fn)), fields.next.identifier, runtime.index(stmt.cpMutSourceIdent, defaultParams(fn)))
+    else:
+      runtime.ir.copyAtom(runtime.index(stmt.cpMutSourceIdent, defaultParams(fn)), dest)
   of CopyValImmut:
     debug "emitter: generate IR for copying value to an immutable address with source: " &
       stmt.cpImmutSourceIdent & " and destination: " & stmt.cpImmutDestIdent

--- a/src/bali/runtime/codegen.nim
+++ b/src/bali/runtime/codegen.nim
@@ -705,7 +705,11 @@ proc generateIR*(
       let fields = createFieldAccess(stmt.cpMutDestIdent.split('.'))
 
       # TODO: recursively find the field to modify
-      runtime.ir.writeField(runtime.index(fields.identifier, defaultParams(fn)), fields.next.identifier, runtime.index(stmt.cpMutSourceIdent, defaultParams(fn)))
+      runtime.ir.writeField(
+        runtime.index(fields.identifier, defaultParams(fn)),
+        fields.next.identifier,
+        runtime.index(stmt.cpMutSourceIdent, defaultParams(fn)),
+      )
     else:
       runtime.ir.copyAtom(runtime.index(stmt.cpMutSourceIdent, defaultParams(fn)), dest)
   of CopyValImmut:

--- a/src/bali/runtime/vm/ir/generator.nim
+++ b/src/bali/runtime/vm/ir/generator.nim
@@ -240,7 +240,8 @@ proc writeField*(
   ## For a faster alternative (direct index access), use the `writeField proc<#writeField, IRGenerator, uint, int, uint>` instead.
   gen.addOp(
     IROperation(
-      opCode: WriteField, arguments: @[stackUinteger position, stackStr name, stackUinteger value]
+      opCode: WriteField,
+      arguments: @[stackUinteger position, stackStr name, stackUinteger value],
     )
   )
 

--- a/src/bali/runtime/vm/ir/generator.nim
+++ b/src/bali/runtime/vm/ir/generator.nim
@@ -233,27 +233,27 @@ proc createField*(
 
 # "slow"
 proc writeField*(
-    gen: IRGenerator, position: uint, name: string, value: MAtom
+    gen: IRGenerator, position: uint, name: string, value: uint
 ): uint {.inline, discardable.} =
   ## Modify a field of an object. 
   ## Keep in mind that this can be slow* as it requires a search in the field name-to-index lookup table.
-  ## For a faster alternative (direct index access), use the `writeField proc<#writeField, IRGenerator, uint, int, MAtom>` instead.
+  ## For a faster alternative (direct index access), use the `writeField proc<#writeField, IRGenerator, uint, int, uint>` instead.
   gen.addOp(
     IROperation(
-      opCode: WriteField, arguments: @[stackUinteger position, stackStr name, value]
+      opCode: WriteField, arguments: @[stackUinteger position, stackStr name, stackUinteger value]
     )
   )
 
 # "fast"
 proc writeField*(
-    gen: IRGenerator, position: uint, index: int, value: MAtom
+    gen: IRGenerator, position: uint, index: int, value: uint
 ): uint {.inline, discardable.} =
   ## Modify a field of an object.
-  ## This is the faster alternative to `writeField proc<#writeField, IRGenerator, uint, string, MAtom>`
+  ## This is the faster alternative to `writeField proc<#writeField, IRGenerator, uint, string, uint>`
   gen.addOp(
     IROperation(
       opCode: FastWriteField,
-      arguments: @[stackUinteger position, stackInteger index, value],
+      arguments: @[stackUinteger position, stackInteger index, stackUinteger value],
     )
   )
 

--- a/src/bali/runtime/vm/runtime/pulsar/interpreter.nim
+++ b/src/bali/runtime/vm/runtime/pulsar/interpreter.nim
@@ -930,7 +930,7 @@ proc execute*(interpreter: var PulsarInterpreter, op: var Operation) =
         if *interpreter.registers.retVal:
           &interpreter.registers.retVal
         else:
-          obj(),
+          undefined(),
         idx,
       )
     of 1:

--- a/src/bali/runtime/vm/runtime/pulsar/interpreter.nim
+++ b/src/bali/runtime/vm/runtime/pulsar/interpreter.nim
@@ -926,10 +926,13 @@ proc execute*(interpreter: var PulsarInterpreter, op: var Operation) =
     case regId
     of 0:
       # 0 - retval register
+      debug "vm: read retval register (#0); placing onto stack pos " & $idx
       interpreter.addAtom(
         if *interpreter.registers.retVal:
+          debug "vm: RREG: retval register is not empty"
           &interpreter.registers.retVal
         else:
+          debug "vm: RREG: retval register is empty, filling in with undefined"
           undefined(),
         idx,
       )
@@ -948,9 +951,9 @@ proc execute*(interpreter: var PulsarInterpreter, op: var Operation) =
     inc interpreter.currIndex
   of PassArgument:
     # append to callArgs register
-    let
-      idx = (&op.arguments[0].getInt()).uint
-      value = &interpreter.get(idx)
+    let idx = (&op.arguments[0].getInt()).uint
+    debug "vm: PARG: appending index to callargs register: " & $idx
+    let value = &interpreter.get(idx)
 
     interpreter.registers.callArgs.add(value)
     inc interpreter.currIndex

--- a/src/bali/runtime/vm/runtime/pulsar/interpreter.nim
+++ b/src/bali/runtime/vm/runtime/pulsar/interpreter.nim
@@ -749,6 +749,7 @@ proc execute*(interpreter: var PulsarInterpreter, op: var Operation) =
     let
       oatomIndex = (&op.arguments[0].getInt()).uint
       oatomId = interpreter.get(oatomIndex)
+      fieldName = &op.arguments[1].getStr()
 
     if not *oatomId:
       inc interpreter.currIndex
@@ -759,15 +760,15 @@ proc execute*(interpreter: var PulsarInterpreter, op: var Operation) =
       fieldIndex = none(int)
 
     for field, idx in atom.objFields:
-      if field == &(op.arguments[1].getStr()):
+      if field == fieldName:
         fieldIndex = some(idx)
 
     if not *fieldIndex:
-      inc interpreter.currIndex
-      return
+      atom.objValues &= undefined()
+      fieldIndex = some(atom.objValues.len - 1)
 
     let toWrite = op.consume(Integer, "", enforce = false, some(op.rawArgs.len - 1))
-    atom.objValues[&fieldIndex] = toWrite
+    atom.objValues[&fieldIndex] = &interpreter.get(uint(&toWrite.getInt()))
 
     interpreter.addAtom(atom, oatomIndex)
     inc interpreter.currIndex

--- a/src/bali/stdlib/prelude.nim
+++ b/src/bali/stdlib/prelude.nim
@@ -3,8 +3,8 @@ import ./builtins/[base64, parse_int, test262, encode_uri]
 import ./types/[std_string, std_bigint, std_number, std_set]
 
 export
-  console, math, uri, parse_int, errors, test262, base64, json, constants,
-  encode_uri, errors_ir, errors_common, std_string, std_bigint, std_number, std_set
+  console, math, uri, parse_int, errors, test262, base64, json, constants, encode_uri,
+  errors_ir, errors_common, std_string, std_bigint, std_number, std_set
 
 when not defined(baliTest262FyiDisableICULinkingCode):
   import ./date

--- a/tests/data/modify-str-prototype-001.js
+++ b/tests/data/modify-str-prototype-001.js
@@ -1,0 +1,9 @@
+var x = new String("Hello")
+
+function thing() {
+	console.log("mrrp :3")
+}
+
+x.toString = thing;
+
+console.log(x.toString)

--- a/tests/data/modify-str-prototype-001.js
+++ b/tests/data/modify-str-prototype-001.js
@@ -1,9 +1,12 @@
 var x = new String("Hello")
 
-function thing() {
+function thing(str) {
+	// This function is passed a JSValue that is internally represented as a boxed string
 	console.log("mrrp :3")
 }
 
 x.toString = thing;
 
 console.log(x.toString)
+let v = x.toString()
+console.log(v)


### PR DESCRIPTION
- **add: codegen: `CopyValMut` handles field resolution**
- **fix: vm: correct `CFIELD`'s broken semantics**
- **chore: fmt**
- **fix: `GetMethod` now respects bytecode/native segments**
- **xxx: enable mimalloc by default, again**
- **fix: vm: `RREG` load `undefined` instead of empty object**
- **fix: codegen: fix some regressions**
- **fix: codegen: migrate `Waste` to new calling system**
- **fix: balde: don't parse line twice**
- **fix: do some stuff**

fixes #104
