### PR TITLE
Moar parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifeq ($(DEBUG), 1)
 endif
 
 balde:
-	$(NIM) cpp $(NIMFLAGS) --define:NimblePkgVersion=$(VERSION) --cc:$(CXX) --out:bin/balde src/balde.nim
+	$(NIM) cpp $(NIMFLAGS) --parallelBuild:0 --define:NimblePkgVersion=$(VERSION) --cc:$(CXX) --out:bin/balde src/balde.nim
 
 clean:
 	rm bin/balde

--- a/README.md
+++ b/README.md
@@ -142,5 +142,6 @@ runtime.run()
 - [X] Functions as values
 - [X] For-loops
 - [X] Try-catch clauses
-- [X] Modules
-- [X] Async
+- [X] Compound assignments
+- [ ] Modules
+- [ ] Async

--- a/bali.nimble
+++ b/bali.nimble
@@ -33,6 +33,7 @@ requires "zippy >= 0.10.16"
 requires "nimsimd >= 1.3.2"
 requires "flatty >= 0.3.4"
 requires "ptr_math >= 0.3.0"
+requires "libbacktrace >= 0.0.8"
 
 taskRequires "fmt", "nph#master"
 task fmt, "Format code":

--- a/bali.nimble
+++ b/bali.nimble
@@ -34,6 +34,7 @@ requires "nimsimd >= 1.3.2"
 requires "flatty >= 0.3.4"
 requires "ptr_math >= 0.3.0"
 requires "libbacktrace >= 0.0.8"
+requires "shakar >= 0.1.0"
 
 taskRequires "fmt", "nph#master"
 task fmt, "Format code":

--- a/nim.cfg
+++ b/nim.cfg
@@ -8,6 +8,11 @@
 
 warning:UnreachableCode:off
 
+--stacktrace:off
+-d:nimStackTraceOverride
+--import:libbacktrace
+--debugger:native
+
 @if not release:
   --warningAsError:UnusedImport:on
   --warningAsError:Uninit:on

--- a/src/bali/grammar/statement.nim
+++ b/src/bali/grammar/statement.nim
@@ -32,6 +32,7 @@ type
     TernaryOp
     ForLoop
     TryCatch
+    CompoundAssignment
 
   FieldAccess* = ref object
     prev*, next*: FieldAccess
@@ -167,6 +168,10 @@ type
       tryStmtBody*: Scope
       tryCatchBody*: Option[Scope]
       tryErrorCaptureIdent*: Option[string]
+    of CompoundAssignment:
+      compAsgnOp*: BinaryOperation
+      compAsgnTarget*: string
+      compAsgnCompounder*: MAtom
 
 func hash*(access: FieldAccess): Hash {.inline.} =
   hash((access.identifier))
@@ -394,6 +399,18 @@ proc callFunction*(name: string, ident: string): FunctionCall =
 
 proc callFunction*(name: string, field: FieldAccess): FunctionCall =
   FunctionCall(function: name, field: some field)
+
+proc compoundAssignment*(
+  op: BinaryOperation,
+  target: string,
+  compounder: MAtom
+): Statement =
+  Statement(
+    kind: CompoundAssignment,
+    compAsgnTarget: target,
+    compAsgnCompounder: compounder,
+    compAsgnOp: op
+  )
 
 {.pop.}
 

--- a/src/bali/grammar/tokenizer.nim
+++ b/src/bali/grammar/tokenizer.nim
@@ -452,10 +452,8 @@ proc consumePlus*(tokenizer: Tokenizer): Token =
   of '+':
     tokenizer.advance()
     return Token(kind: TokenKind.Increment)
-  of strutils.Whitespace:
-    return Token(kind: TokenKind.Add)
   else:
-    return Token(kind: TokenKind.Invalid)
+    return Token(kind: TokenKind.Add)
 
 proc consumeAmpersand*(tokenizer: Tokenizer): Token =
   tokenizer.advance()

--- a/src/bali/runtime/codegen.nim
+++ b/src/bali/runtime/codegen.nim
@@ -1053,6 +1053,15 @@ proc genTryClause(runtime: Runtime, fn: Function, stmt: Statement) =
 
     runtime.generateBytecodeForScope(&stmt.tryCatchBody, allocateConstants = false)
 
+proc genCompoundAsgn(runtime: Runtime, fn: Function, stmt: Statement) =
+  debug "emitter: generate bytecode for compound assignment"
+  case stmt.compAsgnOp
+  of BinaryOperation.Mult:
+    let index = runtime.index(stmt.compAsgnTarget, defaultParams(fn))
+    let compounder = runtime.loadIRAtom(stmt.compAsgnCompounder)
+    runtime.ir.multInt(index, compounder)
+  else: unreachable
+
 proc generateBytecode(
     runtime: Runtime,
     fn: Function,
@@ -1119,6 +1128,8 @@ proc generateBytecode(
     runtime.genForLoop(fn = fn, stmt = stmt)
   of TryCatch:
     runtime.genTryClause(fn = fn, stmt = stmt)
+  of CompoundAssignment:
+    runtime.genCompoundAsgn(fn = fn, stmt = stmt)
   else:
     warn "emitter: unimplemented bytecode generation directive: " & $stmt.kind
 

--- a/src/bali/runtime/codegen.nim
+++ b/src/bali/runtime/codegen.nim
@@ -1055,11 +1055,18 @@ proc genTryClause(runtime: Runtime, fn: Function, stmt: Statement) =
 
 proc genCompoundAsgn(runtime: Runtime, fn: Function, stmt: Statement) =
   debug "emitter: generate bytecode for compound assignment"
+  let target = runtime.index(stmt.compAsgnTarget, defaultParams(fn))
+  let compounder = runtime.loadIRAtom(stmt.compAsgnCompounder)
+
   case stmt.compAsgnOp
   of BinaryOperation.Mult:
-    let index = runtime.index(stmt.compAsgnTarget, defaultParams(fn))
-    let compounder = runtime.loadIRAtom(stmt.compAsgnCompounder)
-    runtime.ir.multInt(index, compounder)
+    runtime.ir.multInt(target, compounder)
+  of BinaryOperation.Div:
+    runtime.ir.divInt(target, compounder)
+  of BinaryOperation.Add:
+    runtime.ir.addInt(target, compounder)
+  of BinaryOperation.Sub:
+    runtime.ir.subInt(target, compounder)
   else: unreachable
 
 proc generateBytecode(

--- a/src/bali/runtime/vm/runtime/pulsar/interpreter.nim
+++ b/src/bali/runtime/vm/runtime/pulsar/interpreter.nim
@@ -872,10 +872,13 @@ proc execute*(interpreter: var PulsarInterpreter, op: var Operation) =
       idx = (&op.arguments[0].getInt()).uint
       regIndex = if op.arguments.len > 2: 2 else: 1
       regId = (&op.arguments[regIndex].getInt())
+
+    msg "idx: " & $idx & ", regIndex: " & $regIndex & ", regId: " & $regId
     
     case regId
     of 0:
       # 0 - retval register
+      msg "read retval register"
       interpreter.addAtom(
         if *interpreter.registers.retVal:
           &interpreter.registers.retVal
@@ -885,11 +888,13 @@ proc execute*(interpreter: var PulsarInterpreter, op: var Operation) =
       )
     of 1:
       # 1 - callargs register
+      msg "read callargs register"
       interpreter.addAtom(
         interpreter.registers.callArgs[&op.arguments[1].getInt()], idx
       )
     of 2:
       # 2 - error register
+      msg "read error register"
       interpreter.addAtom(
         if *interpreter.registers.error:
           &interpreter.registers.error
@@ -906,6 +911,7 @@ proc execute*(interpreter: var PulsarInterpreter, op: var Operation) =
   of PassArgument:
     # append to callArgs register
     let idx = (&op.arguments[0].getInt()).uint
+    msg "passing to args register: " & $idx
     let value = &interpreter.get(idx)
 
     interpreter.registers.callArgs.add(value)
@@ -1096,12 +1102,14 @@ proc execute*(interpreter: var PulsarInterpreter, op: var Operation) =
       let callable = &interpreter.get(uint(&getInt(value)))
 
       if callable.kind == BytecodeCallable:
+        msg "atom is bytecode segment"
         interpreter.call(&getBytecodeClause(callable), op)
       elif callable.kind == NativeCallable:
+        msg "atom is native segment"
         callable.fn()
+        inc interpreter.currIndex
       else:
         raise newException(ValueError, "INVK cannot deal with atom: " & $callable.kind)
-      inc interpreter.currIndex
     elif value.kind == String:
       msg "atom is string/ref to native function"
       interpreter.call(&getStr(value), op)

--- a/tests/data/reassign-expr.js
+++ b/tests/data/reassign-expr.js
@@ -1,0 +1,5 @@
+let x = 32
+assert.sameValue(x, 32)
+
+x = 1335 + 2
+assert.sameValue(x, 1337)


### PR DESCRIPTION
- **fix: vm: `INVK` should only increment pc if native segment is called**
- **fix: use libbacktrace for balde**
- **deps: add `shakar`**
- **fix: parser: reassignments should handle expressions**
- **add: parser+codegen: support for compound assignments**
- **xxx: update README.md**
- **fix: grammar/tokenizer: plus succeeded by non-whitespace should not be invalid**
- **add: grammar/parser: support for more compound assignments**
- **add: runtime/codegen: support for more compound assignments**
