### PR TITLE
Runtime state isolation

### DIFF
--- a/src/bali/runtime/abstract/coercible.nim
+++ b/src/bali/runtime/abstract/coercible.nim
@@ -5,6 +5,6 @@ import bali/stdlib/errors
 proc RequireObjectCoercible*(runtime: Runtime, value: JSValue): JSValue {.inline.} =
   if value.kind == Null:
     runtime.typeError("Object is not coercible: " & value.crush())
-    return null()
+    return null(runtime.heapManager)
 
   value

--- a/src/bali/runtime/abstract/equating.nim
+++ b/src/bali/runtime/abstract/equating.nim
@@ -3,7 +3,7 @@
 ## Author: Trayambak Rai (xtrayambak at disroot dot org)
 import pkg/[bali/runtime/vm/atom, gmp/gmp]
 import pkg/ferrite/utf16view
-import bali/runtime/[atom_helpers, types, bridge]
+import bali/runtime/[atom_helpers, types, bridge, construction]
 import bali/runtime/abstract/[coercion]
 import bali/internal/sugar
 import bali/stdlib/types/[std_bigint, std_string_type]
@@ -106,11 +106,11 @@ proc isLooselyEqual*(runtime: Runtime, x, y: JSValue): bool =
 
   # 5. If x is a Number and y is a String, return ! IsLooselyEqual(x, ! ToNumber(y))
   if x.isNumber and runtime.isA(y, JSString):
-    return runtime.isLooselyEqual(x, floating(runtime.ToNumber(y)))
+    return runtime.isLooselyEqual(x, floating(runtime, runtime.ToNumber(y)))
 
   # 6. If x is a String and y is a Number, return ! IsLooselyEqual(! ToNumber(x), y).
   if runtime.isA(x, JSString) and y.isNumber:
-    return runtime.isLooselyEqual(floating(runtime.ToNumber(x)), y)
+    return runtime.isLooselyEqual(floating(runtime, runtime.ToNumber(x)), y)
 
   # 7. If x is a BigInt and y is a String, then
   if x.isBigInt and runtime.isA(y, JSString):
@@ -141,11 +141,11 @@ proc isLooselyEqual*(runtime: Runtime, x, y: JSValue): bool =
 
   # 9. If x is a Boolean, return ! IsLooselyEqual(! ToNumber(x), y).
   if x.kind == Boolean:
-    return runtime.isLooselyEqual(floating(runtime.ToNumber(x)), y)
+    return runtime.isLooselyEqual(floating(runtime, runtime.ToNumber(x)), y)
 
   # 10. If y is a Boolean, return ! IsLooselyEqual(x, ! ToNumber(y)).
   if y.kind == Boolean:
-    return runtime.isLooselyEqual(x, floating(runtime.ToNumber(y)))
+    return runtime.isLooselyEqual(x, floating(runtime, runtime.ToNumber(y)))
 
   # 11. If x is either a String, a Number, a BigInt, or a Symbol and y is an Object, return ! IsLooselyEqual(x, ? ToPrimitive(y)).
   if (runtime.isA(x, JSString) or x.isBigInt or x.isNumber) and y.isObject:

--- a/src/bali/runtime/abstract/to_number.nim
+++ b/src/bali/runtime/abstract/to_number.nim
@@ -70,7 +70,7 @@ proc ToNumeric*(runtime: Runtime, value: JSValue): JSValue =
     return primValue
 
   # 3. Return ? ToNumber(primValue)
-  floating(runtime.ToNumber(primValue))
+  floating(runtime.heapManager, runtime.ToNumber(primValue))
 
 proc isFiniteNumber*(runtime: Runtime, number: JSValue): bool {.inline.} =
   if not isNumber(number):

--- a/src/bali/runtime/arguments.nim
+++ b/src/bali/runtime/arguments.nim
@@ -31,6 +31,6 @@ proc argument*(
       return
     else:
       debug "runtime: argument(): `required` == false, ignoring and returning `undefined`"
-      return some(undefined())
+      return some(undefined(runtime.heapManager))
 
   some(runtime.vm.registers.callArgs[position - 1])

--- a/src/bali/runtime/atom_helpers.nim
+++ b/src/bali/runtime/atom_helpers.nim
@@ -1,7 +1,7 @@
 ## Atom functions
 
 import std/[options, tables]
-import bali/runtime/vm/atom
+import bali/runtime/vm/atom, bali/runtime/vm/heap/manager
 
 {.push warning[UnreachableCode]: off, inline.}
 
@@ -36,8 +36,8 @@ proc `[]=`*(atom: JSValue, name: string, value: sink JSValue) =
   else:
     atom.objValues[atom.objFields[name]] = ensureMove(value)
 
-proc createField*(atom: JSValue, field: string) =
-  atom[field] = undefined()
+proc createField*(atom: JSValue, field: string, heap: HeapManager) =
+  atom[field] = undefined(heap)
 
 proc contains*(atom: JSValue, name: string): bool =
   atom.objFields.contains(name)

--- a/src/bali/runtime/compiler/amd64/midtier.nim
+++ b/src/bali/runtime/compiler/amd64/midtier.nim
@@ -38,7 +38,7 @@ proc compileLowered(
       alignStack 8:
         cgen.s.mov(regR9, cast[int64](num))
         cgen.s.movq(regR9.reg, regXmm0)
-        cgen.s.mov(regRsi, cast[int64](cgen.vm))
+        cgen.s.mov(regRdi, cast[int64](cgen.vm))
         cgen.s.call(cgen.callbacks.allocEncodedFloat)
 
       cgen.s.mov(regRsi.reg, regRax)

--- a/src/bali/runtime/compiler/amd64/midtier.nim
+++ b/src/bali/runtime/compiler/amd64/midtier.nim
@@ -38,7 +38,8 @@ proc compileLowered(
       alignStack 8:
         cgen.s.mov(regR9, cast[int64](num))
         cgen.s.movq(regR9.reg, regXmm0)
-        cgen.s.call(allocFloatEncoded)
+        cgen.s.mov(regRsi, cast[int64](cgen.vm))
+        cgen.s.call(cgen.callbacks.allocEncodedFloat)
 
       cgen.s.mov(regRsi.reg, regRax)
 
@@ -59,10 +60,11 @@ proc compileLowered(
         cgen.s.call(cgen.callbacks.getAtom)
 
       cgen.s.pop(regRsi.reg)
-      cgen.s.mov(regRdi.reg, regRax)
+      cgen.s.mov(regRsi.reg, regRax)
+      cgen.s.mov(regRdi, cast[int64](cgen.vm))
 
       alignStack 8:
-        cgen.s.call(getProperty)
+        cgen.s.call(cgen.callbacks.getProperty)
 
       cgen.s.mov(regRsi.reg, regRax)
 
@@ -99,8 +101,9 @@ proc compileLowered(
       prepareLoadString(cgen, cstring(str))
 
       alignStack 8:
-        cgen.s.mov(regRdi.reg, regR8)
-        cgen.s.call(strRaw)
+        cgen.s.mov(regRdi, cast[int64](cgen.vm))
+        cgen.s.mov(regRsi.reg, regR8)
+        cgen.s.call(cgen.callbacks.allocStr)
 
       cgen.s.mov(regRsi.reg, regRax)
 
@@ -129,7 +132,8 @@ proc compileLowered(
         cgen.s.call(getRawFloat)
 
         cgen.s.addsd(regXmm0, regXmm1.reg)
-        cgen.s.call(allocFloat)
+        cgen.s.mov(regRdi, cast[int64](cgen.vm))
+        cgen.s.call(cgen.callbacks.allocFloat)
 
         cgen.s.mov(regRdi, cast[int64](cgen.vm))
         cgen.s.mov(regRsi.reg, regRax)
@@ -158,7 +162,8 @@ proc compileLowered(
 
         cgen.s.subsd(regXmm1, regXmm0.reg)
         cgen.s.movsd(regXmm0, regXmm1.reg)
-        cgen.s.call(allocFloat)
+        cgen.s.mov(regRdi, cast[int64](cgen.vm))
+        cgen.s.call(cgen.callbacks.addAtom)
 
         cgen.s.mov(regRdi, cast[int64](cgen.vm))
         cgen.s.mov(regRsi.reg, regRax)
@@ -186,7 +191,8 @@ proc compileLowered(
         cgen.s.call(getRawFloat)
 
         cgen.s.mulsd(regXmm0, regXmm1.reg)
-        cgen.s.call(allocFloat)
+        cgen.s.mov(regRdi, cast[int64](cgen.vm))
+        cgen.s.call(cgen.callbacks.allocFloat)
 
         cgen.s.mov(regRdi, cast[int64](cgen.vm))
         cgen.s.mov(regRsi.reg, regRax)
@@ -215,7 +221,8 @@ proc compileLowered(
 
         cgen.s.ddivsd(regXmm1, regXmm0.reg)
         cgen.s.movsd(regXmm0, regXmm1.reg)
-        cgen.s.call(allocFloat)
+        cgen.s.mov(regRdi, cast[int64](cgen.vm))
+        cgen.s.call(cgen.callbacks.allocFloat)
 
         cgen.s.mov(regRdi, cast[int64](cgen.vm))
         cgen.s.mov(regRsi.reg, regRax)
@@ -267,7 +274,9 @@ proc compile*(cgen: var MidtierJIT, clause: Clause): Option[JITSegment] =
 
   return compileLowered(cgen, pipeline)
 
-proc initAMD64MidtierCodegen*(vm: pointer, callbacks: VMCallbacks): MidtierJIT =
+proc initAMD64MidtierCodegen*(
+    vm: pointer, heap: HeapManager, callbacks: VMCallbacks
+): MidtierJIT =
   info "jit/amd64: initializing midtier jit"
 
-  MidtierJIT(vm: vm, callbacks: callbacks, s: initAssemblerX64())
+  MidtierJIT(vm: vm, heap: heap, callbacks: callbacks, s: initAssemblerX64())

--- a/src/bali/runtime/compiler/amd64/native_forwarding.nim
+++ b/src/bali/runtime/compiler/amd64/native_forwarding.nim
@@ -1,44 +1,10 @@
 ## This file contains some helper functions used by the AMD64 JIT.
 ## These are often called by JIT'd code segments to "forward" work.
-import
-  pkg/bali/runtime/vm/atom,
-  pkg/bali/runtime/atom_helpers,
-  pkg/bali/runtime/vm/heap/manager
+import pkg/bali/runtime/vm/atom
 import pkg/shakar
-
-proc createFieldRaw*(atom: JSValue, field: cstring) {.cdecl.} =
-  atom[$field] = undefined()
 
 proc getRawFloat*(atom: JSValue): float64 {.cdecl.} =
   &atom.getNumeric()
 
-proc allocFloat*(v: float64): JSValue {.cdecl.} =
-  floating v
-
-proc allocFloatEncoded*(v: int64): JSValue {.cdecl.} =
-  allocFloat(cast[float64](v))
-
-proc allocRaw*(size: int64): pointer {.cdecl.} =
-  getHeapManager().allocate(uint(size))
-
 proc copyRaw*(dest, source: pointer, size: uint) {.cdecl.} =
   copyMem(dest, source, size)
-
-proc allocBytecodeCallable*(str: cstring): JSValue {.cdecl.} =
-  bytecodeCallable($str)
-
-proc strRaw*(value: cstring): JSValue {.cdecl.} =
-  str($value)
-
-proc allocInt*(i: int): JSValue {.cdecl.} =
-  integer(i)
-
-proc allocUint*(i: uint): JSValue {.cdecl.} =
-  integer(i)
-
-proc getProperty*(value: JSValue, field: cstring): JSValue {.cdecl.} =
-  let conv = $field
-  if conv in value:
-    return value[conv]
-
-  undefined()

--- a/src/bali/runtime/compiler/base.nim
+++ b/src/bali/runtime/compiler/base.nim
@@ -21,6 +21,14 @@ type
     readScalarRegister*: pointer
     writeField*: pointer
     addRetval*: pointer
+    createField*: pointer
+    allocEncodedFloat*: pointer
+    allocFloat*: pointer
+    alloc*: pointer
+    allocBytecodeCallable*: pointer
+    allocStr*: pointer
+    allocInt*: pointer
+    getProperty*: pointer
 
   JITSegment* = proc(): void {.cdecl.}
 

--- a/src/bali/runtime/construction.nim
+++ b/src/bali/runtime/construction.nim
@@ -1,0 +1,39 @@
+## Helpers for constructing JSValue(s) without breaking your fingers
+## 
+## Copyright (C) 2025 Trayambak Rai (xtrayambak at disroot dot org)
+
+#!fmt: off
+import pkg/bali/runtime/vm/atom,
+       pkg/bali/runtime/types
+#!fmt: on
+
+{.push inline, sideEffect.}
+
+proc integer*(runtime: Runtime, value: SomeInteger): JSValue =
+  integer(runtime.heapManager, value)
+
+proc floating*(runtime: Runtime, value: SomeFloat | SomeInteger): JSValue =
+  floating(runtime.heapManager, value)
+
+proc str*(runtime: Runtime, value: string): JSValue =
+  str(runtime.heapManager, value)
+
+proc sequence*(runtime: Runtime, value: seq[MAtom]): JSValue =
+  sequence(runtime.heapManager, value)
+
+proc undefined*(runtime: Runtime): JSValue =
+  undefined(runtime.heapManager)
+
+proc null*(runtime: Runtime): JSValue =
+  null(runtime.heapManager)
+
+proc bigint*(runtime: Runtime, value: SomeInteger | string): JSValue =
+  bigint(runtime.heapManager, value)
+
+proc boolean*(runtime: Runtime, value: bool): JSValue =
+  boolean(runtime.heapManager, value)
+
+proc obj*(runtime: Runtime): JSValue =
+  obj(runtime.heapManager)
+
+{.pop.}

--- a/src/bali/runtime/prelude.nim
+++ b/src/bali/runtime/prelude.nim
@@ -1,5 +1,8 @@
 import pkg/bali/runtime/vm/atom
-import pkg/bali/runtime/[atom_helpers, arguments, wrapping, bridge, common, types]
+import
+  pkg/bali/runtime/
+    [atom_helpers, arguments, wrapping, bridge, construction, common, types]
 import pkg/bali/runtime/abstract/coercion
 
-export atom, common, atom_helpers, arguments, coercion, bridge, wrapping, types
+export
+  atom, atom_helpers, arguments, coercion, bridge, construction, common, types, wrapping

--- a/src/bali/runtime/vm/interpreter/operation.nim
+++ b/src/bali/runtime/vm/interpreter/operation.nim
@@ -1,5 +1,5 @@
 import std/[options, tables, strutils]
-import pkg/bali/runtime/vm/[atom, shared]
+import pkg/bali/runtime/vm/[atom, shared], pkg/bali/runtime/vm/heap/manager
 import pkg/shakar
 
 const MirageOperationJitThreshold* {.intdefine.} = 8
@@ -40,6 +40,7 @@ proc consume*(
     expects: string,
     enforce: bool = true,
     position: Option[int] = none(int),
+    heap: HeapManager,
 ): JSValue {.inline.} =
   operation.consumed = true
 
@@ -65,18 +66,18 @@ proc consume*(
 
   case raw.kind
   of tkQuotedString:
-    return str raw.str
+    return str(heap, raw.str)
   of tkIdent:
     # if it is a boolean, return it as such
     # otherwise, return as a string
 
     if raw.ident == "true" or raw.ident == "false":
-      return boolean(parseBool(raw.ident))
+      return boolean(heap, parseBool(raw.ident))
 
-    return str raw.ident
+    return str(heap, raw.ident)
   of tkInteger:
-    return integer raw.integer
+    return integer(heap, raw.integer)
   of tkDouble:
-    return floating raw.double.float64
+    return floating(heap, raw.double.float64)
   else:
     discard

--- a/src/bali/runtime/vm/interpreter/resolver.nim
+++ b/src/bali/runtime/vm/interpreter/resolver.nim
@@ -2,130 +2,175 @@ import std/[options, tables]
 import
   pkg/bali/runtime/vm/interpreter/[types, operation],
   pkg/bali/runtime/vm/shared,
-  pkg/bali/runtime/vm/atom
+  pkg/bali/runtime/vm/atom,
+  pkg/bali/runtime/vm/heap/manager
 
 const SequenceBasedRegisters* = [some(1)]
 
-proc resolve*(clause: Clause, op: var Operation) =
+proc resolve*(clause: Clause, op: var Operation, heap: HeapManager) =
   if op.resolved:
     return
 
   case op.opCode
   of LoadStr:
-    op.arguments &= op.consume(Integer, "LOADS expects an integer at position 1")
-    op.arguments &= op.consume(String, "LOADS expects a string at position 2")
+    op.arguments &=
+      op.consume(Integer, "LOADS expects an integer at position 1", heap = heap)
+    op.arguments &=
+      op.consume(String, "LOADS expects a string at position 2", heap = heap)
   of LoadInt, LoadUint:
     for x in 1 .. 2:
       op.arguments &=
         op.consume(
-          Integer, OpCodeToString[op.opCode] & " expects an integer at position " & $x
+          Integer,
+          OpCodeToString[op.opCode] & " expects an integer at position " & $x,
+          heap = heap,
         )
   of Equate:
     for x, _ in op.rawArgs.deepCopy():
-      op.arguments &= op.consume(Integer, "EQU expects an integer at position " & $x)
+      op.arguments &=
+        op.consume(Integer, "EQU expects an integer at position " & $x, heap = heap)
   of GreaterThanInt, LesserThanInt, GreaterThanEqualInt, LesserThanEqualInt:
     for x in 1 .. 2:
       op.arguments &=
         op.consume(
-          Integer, OpCodeToString[op.opCode] & " expects an integer at position " & $x
+          Integer,
+          OpCodeToString[op.opCode] & " expects an integer at position " & $x,
+          heap = heap,
         )
   of Call:
-    op.arguments &= op.consume(String, "CALL expects an ident/string at position 1")
+    op.arguments &=
+      op.consume(String, "CALL expects an ident/string at position 1", heap = heap)
 
     for i, x in deepCopy(op.rawArgs):
-      op.arguments &= op.consume(Integer, "CALL expects an integer at position " & $i)
+      op.arguments &=
+        op.consume(Integer, "CALL expects an integer at position " & $i, heap = heap)
   of Jump:
     op.arguments &=
-      op.consume(Integer, "JUMP expects exactly one integer as an argument")
+      op.consume(
+        Integer, "JUMP expects exactly one integer as an argument", heap = heap
+      )
   of Add, Mult, Div, Sub, Power:
     for x in 1 .. 2:
       op.arguments &=
         op.consume(
-          Integer, OpCodeToString[op.opCode] & " expects an integer at position " & $x
+          Integer,
+          OpCodeToString[op.opCode] & " expects an integer at position " & $x,
+          heap = heap,
         )
   of LoadList:
-    op.arguments &= op.consume(Integer, "LOADL expects an integer at position 1")
+    op.arguments &=
+      op.consume(Integer, "LOADL expects an integer at position 1", heap = heap)
   of AddList:
-    op.arguments &= op.consume(Integer, "ADDL expects an integer at position 1")
+    op.arguments &=
+      op.consume(Integer, "ADDL expects an integer at position 1", heap = heap)
 
-    op.arguments &= op.consume(Integer, "ADDL expects an integer at position 2")
+    op.arguments &=
+      op.consume(Integer, "ADDL expects an integer at position 2", heap = heap)
   of LoadBool:
-    op.arguments &= op.consume(Integer, "LOADB expects an integer at position 1")
+    op.arguments &=
+      op.consume(Integer, "LOADB expects an integer at position 1", heap = heap)
 
-    op.arguments &= op.consume(Boolean, "LOADB expects a boolean at position 2")
+    op.arguments &=
+      op.consume(Boolean, "LOADB expects a boolean at position 2", heap = heap)
   of Swap:
     for x in 1 .. 2:
-      op.arguments &= op.consume(Integer, "SWAP expects an integer at position " & $x)
+      op.arguments &=
+        op.consume(Integer, "SWAP expects an integer at position " & $x, heap = heap)
   of Return:
-    op.arguments &= op.consume(Integer, "RETURN expects an integer at position 1")
+    op.arguments &=
+      op.consume(Integer, "RETURN expects an integer at position 1", heap = heap)
   of JumpOnError:
-    op.arguments &= op.consume(Integer, "JMPE expects an integer at position 1")
+    op.arguments &=
+      op.consume(Integer, "JMPE expects an integer at position 1", heap = heap)
   of LoadObject:
-    op.arguments &= op.consume(Integer, "LOADO expects an integer at position 1")
+    op.arguments &=
+      op.consume(Integer, "LOADO expects an integer at position 1", heap = heap)
   of LoadUndefined:
-    op.arguments &= op.consume(Integer, "LOADUD expects an integer at position 1")
+    op.arguments &=
+      op.consume(Integer, "LOADUD expects an integer at position 1", heap = heap)
   of CreateField:
     for x in 1 .. 2:
-      op.arguments &= op.consume(Integer, "CFIELD expects an integer at position " & $x)
+      op.arguments &=
+        op.consume(Integer, "CFIELD expects an integer at position " & $x, heap = heap)
 
-    op.arguments &= op.consume(String, "CFIELD expects a string at position 3")
+    op.arguments &=
+      op.consume(String, "CFIELD expects a string at position 3", heap = heap)
   of FastWriteField:
     for x in 1 .. 2:
-      op.arguments &= op.consume(
-        Integer, "FWFIELD expects an integer at position " & $x
-      )
+      op.arguments &=
+        op.consume(Integer, "FWFIELD expects an integer at position " & $x, heap = heap)
   of WriteField:
-    op.arguments &= op.consume(Integer, "WFIELD expects an integer at position 1")
+    op.arguments &=
+      op.consume(Integer, "WFIELD expects an integer at position 1", heap = heap)
 
-    op.arguments &= op.consume(String, "WFIELD expects a string at position 2")
+    op.arguments &=
+      op.consume(String, "WFIELD expects a string at position 2", heap = heap)
   of Increment, Decrement:
     op.arguments &=
       op.consume(
-        Integer, OpCodeToString[op.opCode] & " expects an integer at position 1"
+        Integer,
+        OpCodeToString[op.opCode] & " expects an integer at position 1",
+        heap = heap,
       )
   of CrashInterpreter:
     discard
   of LoadNull:
-    op.arguments &= op.consume(Integer, "LOADN expects an integer at position 1")
+    op.arguments &=
+      op.consume(Integer, "LOADN expects an integer at position 1", heap = heap)
   of ReadRegister:
-    op.arguments &= op.consume(Integer, "RREG expects an integer at position 1")
+    op.arguments &=
+      op.consume(Integer, "RREG expects an integer at position 1", heap = heap)
 
-    op.arguments &= op.consume(Integer, "RREG expects an integer at position 2")
+    op.arguments &=
+      op.consume(Integer, "RREG expects an integer at position 2", heap = heap)
 
     try:
       op.arguments &=
         op.consume(
           Integer,
           "RREG expects an integer at position 3 when accessing a sequence based register",
+          heap = heap,
         )
     except ValueError as exc:
       if op.arguments[1].getInt() in SequenceBasedRegisters:
         raise exc
   of PassArgument:
-    op.arguments &= op.consume(Integer, "PARG expects an integer at position 1")
+    op.arguments &=
+      op.consume(Integer, "PARG expects an integer at position 1", heap = heap)
   of ResetArgs, ZeroRetval:
     discard
   of CopyAtom:
-    op.arguments &= op.consume(Integer, "COPY expects an integer at position 1")
+    op.arguments &=
+      op.consume(Integer, "COPY expects an integer at position 1", heap = heap)
 
-    op.arguments &= op.consume(Integer, "COPY expects an integer at position 2")
+    op.arguments &=
+      op.consume(Integer, "COPY expects an integer at position 2", heap = heap)
   of MoveAtom:
-    op.arguments &= op.consume(Integer, "MOVE expects an integer at position 1")
+    op.arguments &=
+      op.consume(Integer, "MOVE expects an integer at position 1", heap = heap)
 
-    op.arguments &= op.consume(Integer, "MOVE expects an integer at position 2")
+    op.arguments &=
+      op.consume(Integer, "MOVE expects an integer at position 2", heap = heap)
   of LoadFloat:
-    op.arguments &= op.consume(Integer, "LOADF expects an integer at position 1")
+    op.arguments &=
+      op.consume(Integer, "LOADF expects an integer at position 1", heap = heap)
 
-    op.arguments &= op.consume(Float, "LOADF expects an integer at position 2")
+    op.arguments &=
+      op.consume(Float, "LOADF expects an integer at position 2", heap = heap)
   of LoadBytecodeCallable:
-    op.arguments &= op.consume(Integer, "LOADBC expects an integer at position 1")
-    op.arguments &= op.consume(String, "LOADBC expects a string at position 2")
+    op.arguments &=
+      op.consume(Integer, "LOADBC expects an integer at position 1", heap = heap)
+    op.arguments &=
+      op.consume(String, "LOADBC expects a string at position 2", heap = heap)
   of ExecuteBytecodeCallable:
-    op.arguments &= op.consume(Integer, "EXEBC expects an integer at position 1")
+    op.arguments &=
+      op.consume(Integer, "EXEBC expects an integer at position 1", heap = heap)
   of Invoke:
     if op.rawArgs[0].kind == tkInteger:
       # Bytecode callable
-      op.arguments &= op.consume(Integer, "INVK expects an integer at position 1")
+      op.arguments &=
+        op.consume(Integer, "INVK expects an integer at position 1", heap = heap)
     elif op.rawArgs[0].kind in {tkIdent, tkQuotedString}:
       # Clause/Builtin
-      op.arguments &= op.consume(String, "INVK expects an ident/string at position 1")
+      op.arguments &=
+        op.consume(String, "INVK expects an ident/string at position 1", heap = heap)

--- a/src/bali/stdlib/builtins/base64.nim
+++ b/src/bali/stdlib/builtins/base64.nim
@@ -3,8 +3,7 @@
 ##
 
 import std/[options, logging]
-import bali/runtime/vm/prelude
-import bali/runtime/[arguments, types, bridge]
+import bali/runtime/[arguments, types, bridge, construction]
 import bali/runtime/abstract/coercion
 import bali/stdlib/errors
 import bali/internal/sugar
@@ -37,7 +36,7 @@ proc generateStdIr*(runtime: Runtime) =
         strVal = runtime.ToString(value)
 
       try:
-        ret str decode(strVal)
+        ret str(runtime, decode(strVal))
       except Base64DecodeError as exc:
         decodeError,
   )
@@ -57,6 +56,6 @@ proc generateStdIr*(runtime: Runtime) =
         )
         str = runtime.ToString(value)
 
-      ret str encode(str)
+      ret str(runtime, encode(str))
     ,
   )

--- a/src/bali/stdlib/builtins/encode_uri.nim
+++ b/src/bali/stdlib/builtins/encode_uri.nim
@@ -1,10 +1,9 @@
 ## Implementation of encodeURI()
 ## Author(s):
 ## Trayambak Rai (xtrayambak at disroot dot org)
-import bali/runtime/[arguments, bridge, types]
-import bali/runtime/abstract/coercion
-import bali/runtime/vm/atom
-import bali/internal/[sugar, uri_coding]
+import pkg/bali/runtime/[arguments, bridge, types, construction]
+import pkg/bali/runtime/abstract/coercion
+import pkg/bali/internal/[sugar, uri_coding]
 
 proc generateStdIR*(runtime: Runtime) =
   runtime.defineFn(
@@ -14,7 +13,7 @@ proc generateStdIR*(runtime: Runtime) =
         if runtime.argumentCount() > 0:
           &runtime.argument(1)
         else:
-          undefined()
+          undefined(runtime)
 
       # 1. Let uriString be ? ToString(uri)
       let uriString = runtime.ToString(uri)

--- a/src/bali/stdlib/builtins/parse_int.nim
+++ b/src/bali/stdlib/builtins/parse_int.nim
@@ -3,12 +3,12 @@
 
 import std/[strutils, math, options, logging]
 import bali/runtime/vm/prelude
-import bali/runtime/[arguments, types, bridge]
+import bali/runtime/[arguments, types, bridge, construction]
 import bali/internal/[sugar, trim_string]
 
 template parseIntFunctionSubstitution*() =
   if runtime.vm.registers.callArgs.len < 1:
-    runtime.vm.registers.retVal = some floating NaN
+    runtime.vm.registers.retVal = some floating(runtime, NaN)
     return
 
   let
@@ -32,22 +32,22 @@ template parseIntFunctionSubstitution*() =
     runtime.vm.registers.retVal = some(
       case &radix
       of 2:
-        integer parseBinInt(value)
+        integer(runtime, parseBinInt(value))
       of 8:
-        integer parseOctInt(value)
+        integer(runtime, parseOctInt(value))
       of 10:
-        integer parseInt(value)
+        integer(runtime, parseInt(value))
       of 16:
-        integer parseHexInt(value)
+        integer(runtime, parseHexInt(value))
       else:
         if unlikely(&radix < 2 or &radix > 36):
-          floating NaN
+          floating(runtime, NaN)
         else:
-          floating NaN
+          floating(runtime, NaN)
     )
   except ValueError as exc:
     warn "builtins.parse_int(" & $value & "): " & exc.msg & " (radix=" & $radix & ')'
-    runtime.vm.registers.retVal = some floating NaN
+    runtime.vm.registers.retVal = some floating(runtime, NaN)
 
 proc parseIntGenerateStdIr*(runtime: Runtime) =
   info "builtins.parse_int: generating IR interfaces"

--- a/src/bali/stdlib/date.nim
+++ b/src/bali/stdlib/date.nim
@@ -5,7 +5,7 @@
 import std/[math, strformat, times, logging, options]
 import bali/internal/sugar
 import bali/runtime/vm/atom
-import bali/runtime/[atom_helpers, arguments, types, bridge, wrapping]
+import bali/runtime/[atom_helpers, arguments, types, bridge, construction, wrapping]
 import bali/runtime/abstract/[coercion, slots]
 import bali/internal/date/[utils, constants, parser]
 import bali/internal/timezone
@@ -133,7 +133,7 @@ proc generateStdIR*(runtime: Runtime) =
           dateValue = timeClip(runtime.ToNumber(value))
 
       var date = runtime.createObjFromType(JSDate)
-      date.tag("epoch", floating(dateValue))
+      date.tag("epoch", floating(runtime, dateValue))
       ret date
     ,
   )

--- a/src/bali/stdlib/math.nim
+++ b/src/bali/stdlib/math.nim
@@ -45,12 +45,16 @@ proc generateStdIr*(runtime: Runtime) =
   info "math: generating IR interfaces"
 
   runtime.registerType("Math", JSMath)
-  runtime.setProperty(JSMath, "LN10", floating(math.ln(10'f64)))
-  runtime.setProperty(JSMath, "LN2", floating(math.ln(2'f64)))
-  runtime.setProperty(JSMath, "LOG10E", floating(math.log10(math.E)))
-  runtime.setProperty(JSMath, "LOG2E", floating(math.log2(math.E)))
-  runtime.setProperty(JSMath, "SQRT1_2", floating(math.sqrt(1 / 2)))
-  runtime.setProperty(JSMath, "SQRT2", floating(math.sqrt(2'f64)))
+  runtime.setProperty(JSMath, "LN10", floating(runtime.heapManager, math.ln(10'f64)))
+  runtime.setProperty(JSMath, "LN2", floating(runtime.heapManager, math.ln(2'f64)))
+  runtime.setProperty(
+    JSMath, "LOG10E", floating(runtime.heapManager, math.log10(math.E))
+  )
+  runtime.setProperty(JSMath, "LOG2E", floating(runtime.heapManager, math.log2(math.E)))
+  runtime.setProperty(
+    JSMath, "SQRT1_2", floating(runtime.heapManager, math.sqrt(1 / 2))
+  )
+  runtime.setProperty(JSMath, "SQRT2", floating(runtime.heapManager, math.sqrt(2'f64)))
 
   # Math.random
   # WARN: Do not use this for cryptography! This uses one of eight highly predictable pseudo-random
@@ -60,7 +64,7 @@ proc generateStdIr*(runtime: Runtime) =
     "random",
     proc() =
       let value = float64(rng.generator.next()) / 1.8446744073709552e+19'f64
-      ret floating(value)
+      ret value
     ,
   )
 
@@ -73,7 +77,7 @@ proc generateStdIr*(runtime: Runtime) =
         value = runtime.ToNumber(&runtime.argument(1))
         exponent = runtime.ToNumber(&runtime.argument(2))
 
-      ret floating pow(value, exponent)
+      ret pow(value, exponent)
     ,
   )
 
@@ -83,7 +87,7 @@ proc generateStdIr*(runtime: Runtime) =
     "cos",
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
-      ret floating cos(value)
+      ret cos(value)
     ,
   )
 
@@ -93,7 +97,7 @@ proc generateStdIr*(runtime: Runtime) =
     "sqrt",
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
-      ret floating sqrt(value)
+      ret sqrt(value)
     ,
   )
 
@@ -104,7 +108,7 @@ proc generateStdIr*(runtime: Runtime) =
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
-      ret floating tanh(value)
+      ret tanh(value)
     ,
   )
 
@@ -115,7 +119,7 @@ proc generateStdIr*(runtime: Runtime) =
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
-      ret floating sin(value)
+      ret sin(value)
     ,
   )
 
@@ -126,7 +130,7 @@ proc generateStdIr*(runtime: Runtime) =
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
-      ret floating sinh(value)
+      ret sinh(value)
     ,
   )
 
@@ -137,7 +141,7 @@ proc generateStdIr*(runtime: Runtime) =
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
-      ret floating tan(value)
+      ret tan(value)
     ,
   )
 
@@ -148,7 +152,7 @@ proc generateStdIr*(runtime: Runtime) =
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
-      ret floating trunc(value)
+      ret trunc(value)
     ,
   )
 
@@ -159,7 +163,7 @@ proc generateStdIr*(runtime: Runtime) =
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
-      ret floating floor(value)
+      ret floor(value)
     ,
   )
 
@@ -170,7 +174,7 @@ proc generateStdIr*(runtime: Runtime) =
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
-      ret floating ceil(value)
+      ret ceil(value)
     ,
   )
 
@@ -181,7 +185,7 @@ proc generateStdIr*(runtime: Runtime) =
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
-      ret floating cbrt(value)
+      ret cbrt(value)
     ,
   )
 
@@ -192,7 +196,7 @@ proc generateStdIr*(runtime: Runtime) =
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
-      ret floating ln(value)
+      ret ln(value)
     ,
   )
 
@@ -203,7 +207,7 @@ proc generateStdIr*(runtime: Runtime) =
     proc() =
       let value = runtime.ToNumber(&runtime.argument(1))
 
-      ret floating abs(value)
+      ret abs(value)
     ,
   )
 
@@ -216,7 +220,7 @@ proc generateStdIr*(runtime: Runtime) =
         a = runtime.ToNumber(&runtime.argument(1))
         b = runtime.ToNumber(&runtime.argument(2))
 
-      ret floating max(a, b)
+      ret max(a, b)
     ,
   )
 
@@ -229,6 +233,6 @@ proc generateStdIr*(runtime: Runtime) =
         a = runtime.ToNumber(&runtime.argument(1))
         b = runtime.ToNumber(&runtime.argument(2))
 
-      ret floating min(a, b)
+      ret min(a, b)
     ,
   )

--- a/src/bali/stdlib/types/std_bigint.nim
+++ b/src/bali/stdlib/types/std_bigint.nim
@@ -1,7 +1,7 @@
 ## Arbitrary-precision integers
 ## Author: Trayambak Rai (xtrayambak at disroot dot org)
 import std/[options]
-import bali/runtime/[arguments, atom_helpers, types, wrapping, bridge]
+import bali/runtime/[arguments, atom_helpers, types, wrapping, bridge, construction]
 import bali/runtime/abstract/coercion
 import bali/stdlib/errors
 import bali/internal/[sugar, trim_string]
@@ -20,10 +20,10 @@ proc stringToBigInt*(runtime: Runtime, str: JSValue): JSValue =
   var bigint =
     try:
       # 2. Let literal be ParseText(text, StringIntegerLiteral).
-      bigint(text)
+      bigint(runtime, text)
     except ValueError:
       # 3. If literal is a List of errors, return undefined.
-      undefined()
+      undefined(runtime)
 
   # 6. Return ℤ(mv).
   var bigintAtom = runtime.createObjFromType(JSBigInt)
@@ -78,7 +78,7 @@ proc toBigInt*(runtime: Runtime, atom: JSValue): JSValue =
     # Return 1n if prim is true and 0n if prim is false.
 
     var bigint = runtime.createObjFromType(JSBigInt)
-    bigint.tag("value", bigint(int(&prim.getBool())))
+    bigint.tag("value", bigint(runtime, int(&prim.getBool())))
     return bigint
 
 proc numberToBigInt*(runtime: Runtime, primitive: JSValue): JSValue {.inline.} =
@@ -92,7 +92,7 @@ proc numberToBigInt*(runtime: Runtime, primitive: JSValue): JSValue {.inline.} =
 
   var bigint = runtime.createObjFromType(JSBigInt)
 
-  bigint.tag("value", bigint(runtime.ToNumber(primitive).int()))
+  bigint.tag("value", bigint(runtime, runtime.ToNumber(primitive).int()))
 
   bigint
 

--- a/src/bali/stdlib/types/std_number.nim
+++ b/src/bali/stdlib/types/std_number.nim
@@ -1,7 +1,7 @@
 ## Number type
 ## Author: Trayambak Rai (xtrayambak at disroot dot org)
 import std/[math, fenv, logging]
-import bali/runtime/[arguments, bridge, atom_helpers, wrapping, types]
+import bali/runtime/[arguments, bridge, atom_helpers, wrapping, types, construction]
 import bali/runtime/abstract/[to_number, to_string]
 import bali/stdlib/builtins/parse_int
 import bali/stdlib/errors
@@ -127,25 +127,27 @@ proc generateStdIR*(runtime: Runtime) =
 
   # 21.1.2.10 Number.NaN
   # The value of Number.NaN is NaN.
-  runtime.setProperty(JSNumber, "NaN", floating(NaN))
+  runtime.setProperty(JSNumber, "NaN", floating(runtime, NaN))
 
   # 21.1.2.6 Number.MAX_SAFE_INTEGER
   # The value of Number.MAX_SAFE_INTEGER is 9007199254740991𝔽 (𝔽(253 - 1)).
-  runtime.setProperty(JSNumber, "MAX_SAFE_INTEGER", floating(9007199254740991'f64))
+  runtime.setProperty(
+    JSNumber, "MAX_SAFE_INTEGER", floating(runtime, 9007199254740991'f64)
+  )
 
   # 21.1.2.14 Number.POSITIVE_INFINITY
   # The value of Number.POSITIVE_INFINITY is +∞𝔽.
-  runtime.setProperty(JSNumber, "POSITIVE_INFINITY", floating(Inf))
+  runtime.setProperty(JSNumber, "POSITIVE_INFINITY", floating(runtime, Inf))
 
   # 21.1.2.11 Number.NEGATIVE_INFINITY
   # The value of Number.NEGATIVE_INFINITY is -∞∞𝔽.
-  runtime.setProperty(JSNumber, "NEGATIVE_INFINITY", floating(-Inf))
+  runtime.setProperty(JSNumber, "NEGATIVE_INFINITY", floating(runtime, -Inf))
 
   # 21.1.2.1 Number.EPSILON
   # The value of Number.EPSILON is the Number value for the magnitude of the difference between 1
   # and the smallest value greater than 1 that is representable as a Number value, which is approximately
   # 2.2204460492503130808472633361816 × 10-16.
-  runtime.setProperty(JSNumber, "EPSILON", floating(epsilon(float)))
+  runtime.setProperty(JSNumber, "EPSILON", floating(runtime, epsilon(float)))
 
   runtime.definePrototypeFn(
     JSNumber,

--- a/src/bali/stdlib/types/std_set.nim
+++ b/src/bali/stdlib/types/std_set.nim
@@ -1,7 +1,7 @@
 ## Set type implementation
 ## Author: Trayambak Rai (xtrayambak at disroot dot org)
 import std/[options]
-import bali/runtime/[arguments, atom_helpers, types, wrapping, bridge]
+import bali/runtime/[arguments, atom_helpers, types, wrapping, bridge, construction]
 import bali/runtime/abstract/[coercion, equating, slots]
 import bali/internal/sugar
 import bali/runtime/vm/atom
@@ -18,7 +18,7 @@ proc generateStdIR*(runtime: Runtime) =
       # FIXME: Non-compliant.
 
       var set = runtime.createObjFromType(JSSet)
-      set.tag("internal", sequence(@[]))
+      set.tag("internal", sequence(runtime, @[]))
       ret set
     ,
   )
@@ -57,11 +57,11 @@ proc generateStdIR*(runtime: Runtime) =
 
       # 4. If value is -0𝔽, set value to +0𝔽.
       if value.isNumber and runtime.ToNumber(value) == -0f:
-        value = floating(0f)
+        value = floating(runtime, 0f)
 
       # 5. Append value to S.[[SetData]].
       setVal.add(value[])
-      setAtom.tag("internal", sequence(setVal))
+      setAtom.tag("internal", sequence(runtime, setVal))
 
       # 6. Return S.
       ret setAtom
@@ -121,7 +121,7 @@ proc generateStdIR*(runtime: Runtime) =
       if found:
         # i. Replace the element of S.[[SetData]] whose value is e with an element whose value is empty.
         data.delete(index)
-        setAtom.tag("internal", sequence(move(data)))
+        setAtom.tag("internal", sequence(runtime, move(data)))
 
         # ii. Return true.
         ret true
@@ -169,9 +169,9 @@ proc generateStdIR*(runtime: Runtime) =
 
       # 3. For each element e of S.[[SetData]], do
       # a. Replace the element of S.[[SetData]] whose value is e with an element whose value is empty.
-      setAtom.tag("internal", sequence(newSeq[MAtom](0)))
+      setAtom.tag("internal", sequence(runtime, newSeq[MAtom](0)))
 
       # 4. Return undefined.
-      ret undefined()
+      ret undefined(runtime)
     ,
   )

--- a/src/bali/stdlib/types/std_string.nim
+++ b/src/bali/stdlib/types/std_string.nim
@@ -3,7 +3,7 @@
 ## Author(s):
 ## Trayambak Rai (xtrayambak at disroot dot org)
 import std/[tables, strutils, hashes, unicode]
-import bali/runtime/[arguments, bridge, wrapping, atom_helpers, types]
+import bali/runtime/[arguments, bridge, wrapping, atom_helpers, types, construction]
 import bali/runtime/abstract/[coercible, to_number, to_string]
 import bali/stdlib/errors, bali/stdlib/types/std_string_type
 import bali/internal/[trim_string, sugar]
@@ -21,7 +21,7 @@ proc generateStdIr*(runtime: Runtime) =
       if runtime.argumentCount > 0:
         &runtime.argument(1)
       else:
-        str("")
+        str(runtime, newString(0))
 
     let strVal =
       if argument.kind == Object and runtime.isA(argument, JSString):
@@ -35,8 +35,8 @@ proc generateStdIr*(runtime: Runtime) =
       ret argument
 
     var atom = runtime.createObjFromType(JSString)
-    atom["@internal"] = str(strVal)
-    atom["length"] = integer(newUtf16View(strVal).codeunitLen().int)
+    atom["@internal"] = str(runtime, strVal)
+    atom["length"] = integer(runtime, newUtf16View(strVal).codeunitLen().int)
     ret atom
 
   runtime.defineConstructor("String", stringConstructor)
@@ -246,7 +246,7 @@ proc generateStdIr*(runtime: Runtime) =
 
       # 5. If position < 0 or position ≥ size, return undefined.
       if position < 0 or position >= size:
-        ret undefined()
+        ret undefined(runtime)
 
       # 6. Let cp be CodePointAt(S, position).
       let codepoint = newUtf16View(str).codePointAt(position.uint())
@@ -360,7 +360,7 @@ proc generateStdIr*(runtime: Runtime) =
 
       # 7. If k < 0 or k ≥ len, return undefined.
       if k < 0 or k >= size:
-        ret undefined()
+        ret undefined(runtime)
 
       # 8. Return the substring of S from k to k + 1.
       ret newJSString(runtime, str[k ..< k + 1])

--- a/src/bali/stdlib/types/std_string_type.nim
+++ b/src/bali/stdlib/types/std_string_type.nim
@@ -16,7 +16,7 @@ func value*(str: JSString): string {.inline.} =
 proc newJSString*(runtime: Runtime, native: string): JSValue =
   ## Given a native string, turn it into a `JSString` allocated on the heap.
   var str = runtime.createObjFromType(JSString)
-  str.tag("internal", native.str())
+  str.tag("internal", str(runtime.heapManager, native))
 
   ensureMove(str)
 

--- a/src/bali/stdlib/uri.nim
+++ b/src/bali/stdlib/uri.nim
@@ -1,7 +1,7 @@
 ## JavaScript URL API - uses sanchar's builtin URL parser
 import std/[options, logging]
 import bali/internal/sugar
-import bali/runtime/[arguments, types, atom_helpers, bridge]
+import bali/runtime/[arguments, types, atom_helpers, bridge, construction]
 import bali/runtime/abstract/coercion
 import bali/stdlib/errors
 import bali/stdlib/types/std_string_type
@@ -25,7 +25,7 @@ proc transposeUrlToObject(runtime: Runtime, parsed: URL, source: string): JSValu
   var url = runtime.createObjFromType(JSURL)
   url["hostname"] = runtime.newJSString(parsed.hostname())
   url["pathname"] = runtime.newJSString(parsed.path())
-  url["port"] = parsed.port().int.integer()
+  url["port"] = integer(runtime, parsed.port.int)
   url["protocol"] = runtime.newJSString(parsed.scheme() & ':')
   url["search"] = runtime.newJSString(parsed.query())
   url["hostname"] = runtime.newJSString(parsed.hostname())
@@ -108,7 +108,7 @@ proc generateStdIR*(runtime: Runtime) =
       let source = &ensureMove(osource)
 
       if not runtime.isA(source, JSString):
-        ret null()
+        ret null(runtime)
 
       let str = runtime.ToString(source)
 

--- a/tests/tatom_or_func_001.nim
+++ b/tests/tatom_or_func_001.nim
@@ -5,14 +5,13 @@ import pkg/bali/runtime/vm/heap/manager
 # We need to setup the heap manager ourselves, otherwise
 # the allocations below won't work.
 var heapMgr = initHeapManager()
-setHeapManager(heapMgr)
 
 var v1 = initAtomOrFunction(
   proc(name: string) =
     echo "Hi, " & name
 )
 
-var v2 = initAtomOrFunction[proc()](integer(1337))
+var v2 = initAtomOrFunction[proc()](integer(heapMgr, 1337))
 
 v1.fn()("tray")
 echo v2.atom().crush()


### PR DESCRIPTION
- **feat/ref: *: remove all dependency on global heap manager state**
- **fix: amd64/midtier: put vm ptr in `rdi`, not `rsi`**

This is a relatively _MASSIVE_ MR and it mainly does one thing: prevent Bali from relying on a global, shared, thread-var heap state that was very fragile. \
Now, everything is encapsulated in `Runtime` and `PulsarInterpreter`, meaning in theory, Bali can now be used with several instances at once, without any major issues popping up. \
This should also let you run Bali on another thread, without the compiler crying about it.

This breaks ~99% of code that uses Bali's API, though. I think this deserves a bump from 0.7.8 to 0.8.0.
